### PR TITLE
Harden HPC workflows and publication-ready exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+docs/
+hpc/build/

--- a/ATACseqQCShniy/environment.yaml
+++ b/ATACseqQCShniy/environment.yaml
@@ -10,9 +10,11 @@ dependencies:
   - r-shinyjs
   - r-shinyBS
   - r-shinycssloaders
+  - r-cairo
   - bioconductor-atacseqqc
-  - bioconductor-atacseqqc
+  - bioconductor-bsgenome.hsapiens.ucsc.hg19
   - bioconductor-chippeakanno
+  - bioconductor-txdb.hsapiens.ucsc.hg19.knowngene
   - bioconductor-motifdb
   - bioconductor-genomicalignments
   - bioconductor-rsamtools

--- a/ATACseqQCShniy/src/plot-downloads.R
+++ b/ATACseqQCShniy/src/plot-downloads.R
@@ -1,0 +1,74 @@
+draw_publication_plot <- function(plot_function) {
+    plot_object <- plot_function()
+    if (inherits(plot_object, c("gg", "ggplot", "grob", "gTree", "gtable"))) {
+        print(plot_object)
+    }
+    invisible(plot_object)
+}
+
+register_publication_downloads <- function(
+    output,
+    id,
+    filename,
+    plot_function,
+    width = 8,
+    height = 6
+) {
+    formats <- list(
+        png = list(
+            extension = "png",
+            content_type = "image/png",
+            open = function(file) {
+                grDevices::png(
+                    file,
+                    width = width,
+                    height = height,
+                    units = "in",
+                    res = 300,
+                    type = if (capabilities("cairo")) "cairo" else getOption("bitmapType")
+                )
+            }
+        ),
+        pdf = list(
+            extension = "pdf",
+            content_type = "application/pdf",
+            open = function(file) {
+                grDevices::pdf(file, width = width, height = height, useDingbats = FALSE)
+            }
+        ),
+        svg = list(
+            extension = "svg",
+            content_type = "image/svg+xml",
+            open = function(file) grDevices::svg(file, width = width, height = height)
+        )
+    )
+
+    for (format in names(formats)) {
+        config <- formats[[format]]
+        local({
+            local_format <- format
+            local_config <- config
+            output[[paste0(id, "_", local_format)]] <- shiny::downloadHandler(
+                filename = function() paste0(filename(), ".", local_config$extension),
+                contentType = local_config$content_type,
+                content = function(file) {
+                    local_config$open(file)
+                    on.exit(grDevices::dev.off(), add = TRUE)
+                    draw_publication_plot(plot_function)
+                }
+            )
+        })
+    }
+}
+
+register_publication_png <- function(output, id, filename, source_file) {
+    output[[paste0(id, "_png")]] <- shiny::downloadHandler(
+        filename = function() paste0(filename(), ".png"),
+        contentType = "image/png",
+        content = function(file) {
+            if (!file.copy(source_file(), file, overwrite = TRUE)) {
+                stop("Could not prepare the figure download.", call. = FALSE)
+            }
+        }
+    )
+}

--- a/ATACseqQCShniy/src/server-fragmentsize.R
+++ b/ATACseqQCShniy/src/server-fragmentsize.R
@@ -1,8 +1,12 @@
-output$plot_fragmentsize <-  renderPlot({
-    print(input$sample_fragmentsize)
-    print(my_values$samples_df[input$sample_fragmentsize, 'BamFile'])
-
+fragment_size_plot <- reactive({
+    req(input$sample_fragmentsize, my_values$base_dir)
     bamfile <- file.path(my_values$base_dir,my_values$samples_df[input$sample_fragmentsize, 'BamFile'])
-    print(bamfile)
-    fragSize <- fragSizeDist(bamfile, input$sample_fragmentsize)
+    fragSizeDist(bamfile, input$sample_fragmentsize)
 })
+
+output$plot_fragmentsize <- renderPlot(fragment_size_plot())
+register_publication_downloads(
+    output, "download_fragment_size",
+    function() paste0("atacseq-fragment-size-", input$sample_fragmentsize),
+    fragment_size_plot, width = 8.5, height = 6
+)

--- a/ATACseqQCShniy/src/server-heatmap.R
+++ b/ATACseqQCShniy/src/server-heatmap.R
@@ -16,18 +16,30 @@ output$multiple_bamfiles <- reactive({
 })
 outputOptions(output, "multiple_bamfiles", suspendWhenHidden = FALSE)
 
-output$plot_heatmap <-  renderPlot({
-
-
+replicate_heatmap_plot <- reactive({
+    req(
+        my_values$base_dir,
+        input$sel_chromosome_heatmap_tab,
+        input$bs_genome_input
+    )
+    chromosome <- trimws(input$sel_chromosome_heatmap_tab)
+    validate(need(nzchar(chromosome), "Select a chromosome to generate the heatmap."))
 
     # path <- system.file("extdata", package="ATACseqQC", mustWork=TRUE)
     path <- my_values$base_dir
     bamfiles <- dir(path, "*.bam$", full.name=TRUE)
-
-    
+    req(length(bamfiles) > 1)
+    available_chromosomes <- names(scanBamHeader(bamfiles[[1]])[[1]]$targets)
+    validate(need(
+        chromosome %in% available_chromosomes,
+        "The selected chromosome is not present in the BAM files."
+    ))
     
     gals <- lapply(bamfiles, function(bamfile){
-                param <- ScanBamParam(tag=character(0), which=GRanges(input$sel_chromosome_heatmap_tab, IRanges(1, 1e6)))
+                param <- ScanBamParam(
+                    tag = character(0),
+                    which = GRanges(chromosome, IRanges(1, 1e6))
+                )
                 # bfile <- readBamFile(bamFile=bamfile, tag=character(0), 
                 #             which=GRanges(input$sel_chromosome_heatmap_tab, IRanges(1, 1e6)), 
                 #             asMates=TRUE, bigFile=TRUE)
@@ -39,14 +51,14 @@ output$plot_heatmap <-  renderPlot({
     check_and_load_bioc_package(input$bs_genome_input)
     # library(TxDb.Hsapiens.UCSC.hg19.knownGene)
     tx_db <- tx_db_list[[input$bs_genome_input]]
-    print(tx_db)
-    # library(tx_db, character.only = T)
     check_and_load_bioc_package(tx_db)
-
-    print(get(tx_db))
     txs <- transcripts(get(tx_db))
-  
-    plotCorrelation(GAlignmentsList(gals), txs, seqlev=input$sel_chromosome_heatmap_tab)
-
+    plotCorrelation(GAlignmentsList(gals), txs, seqlev = chromosome)
 })
 
+output$plot_heatmap <- renderPlot(replicate_heatmap_plot())
+register_publication_downloads(
+    output, "download_replicate_heatmap",
+    function() paste0("atacseq-replicate-correlation-", input$sel_chromosome_heatmap_tab),
+    replicate_heatmap_plot, width = 8, height = 7
+)

--- a/ATACseqQCShniy/src/server-inputdata.R
+++ b/ATACseqQCShniy/src/server-inputdata.R
@@ -52,26 +52,47 @@ observe({
 
 
 my_values <- reactiveValues()
-my_values$mounted_dir <- FALSE
+my_values$scratch_dir <- NULL
 
-observeEvent(input$connect_remote_server, {
-    print(input$username)
-    print(input$hostname)
-    print(input$mountpoint)
-    print(input$id_rsa$datapath)
-    my_values$mounted_dir <- FALSE
+scratch_root <- normalizePath(
+    Sys.getenv("NASQAR_DATA_ROOT", unset = "/scratch/nr83"),
+    winslash = "/",
+    mustWork = FALSE
+)
 
+observeEvent(input$scratch_directory, {
+    my_values$scratch_dir <- NULL
+}, ignoreInit = TRUE)
 
-    system(paste(
-        "sh generate_ssh_config.sh ", input$username, " ",
-        input$hostname, " ", input$mountpoint, " ",
-        input$id_rsa$datapath
-    ))
+observeEvent(input$load_scratch_directory, {
+    requested_dir <- tryCatch(
+        normalizePath(input$scratch_directory, winslash = "/", mustWork = TRUE),
+        error = function(error) NULL
+    )
 
+    if (is.null(requested_dir) || !dir.exists(requested_dir)) {
+        showNotification("Directory does not exist or is not readable.", type = "error")
+        return()
+    }
 
-    # Get the list of files in the directory
-    # files <- list.files(base_dir, full.names = FALSE)
-    my_values$mounted_dir <- TRUE
+    inside_scratch <- identical(requested_dir, scratch_root) ||
+        startsWith(requested_dir, paste0(scratch_root, "/"))
+    if (!inside_scratch) {
+        showNotification(
+            paste("Directory must be inside", scratch_root),
+            type = "error"
+        )
+        return()
+    }
+
+    files <- list.files(requested_dir, full.names = FALSE)
+    if (!any(grepl("\\.bam$", files, ignore.case = TRUE))) {
+        showNotification("No BAM files were found in this directory.", type = "error")
+        return()
+    }
+
+    my_values$scratch_dir <- requested_dir
+    showNotification("BAM directory loaded.", type = "message")
 })
 
 
@@ -108,7 +129,7 @@ input_files_reactive <- reactive({
     # )
 
     shiny::validate(
-        need(identical(input$data_file_type, "example_bam_file") | identical(input$data_file_type, "mount_remote_server") | (identical(input$data_file_type, "upload_bam_file") & !is.null(input$bam_files) & length(input$bam_files$name) > 1),
+        need(identical(input$data_file_type, "example_bam_file") | identical(input$data_file_type, "hpc_scratch_directory") | (identical(input$data_file_type, "upload_bam_file") & !is.null(input$bam_files) & length(input$bam_files$name) > 1),
             message = "Please upload both .bam and .bai files "
         )
     )
@@ -118,8 +139,8 @@ input_files_reactive <- reactive({
 
 
     shiny::validate(
-        need(identical(input$data_file_type, "example_bam_file") | identical(input$data_file_type, "upload_bam_file") | identical(input$data_file_type, "mount_remote_server") & my_values$mounted_dir,
-            message = "Please connect to the server "
+        need(identical(input$data_file_type, "example_bam_file") | identical(input$data_file_type, "upload_bam_file") | (identical(input$data_file_type, "hpc_scratch_directory") & !is.null(my_values$scratch_dir)),
+            message = "Enter a scratch directory and select Load directory."
         )
     )
 
@@ -160,20 +181,35 @@ input_files_reactive <- reactive({
         # Filter BAM and BMI files
         bam_files <- files[grepl(".bam$", files)]
         bai_files <- files[grepl(".bai$", files)]
-    } else {
-        base_dir <- "./mnt"
+    } else if (identical(input$data_file_type, "hpc_scratch_directory")) {
+        base_dir <- my_values$scratch_dir
         # Get the list of files in the directory
         files <- list.files(base_dir, full.names = FALSE)
 
         # Filter BAM and BMI files
-        bam_files <- files[grepl(".bam$", files)]
-        bai_files <- files[grepl(".bai$", files)]
-        matching_files <- sapply(bam_files, function(bam_file) {
-            bmi_file <- gsub(".bam$", ".bai", bam_file)
-            bmi_file %in% bai_files
-        })
-        bam_files <- names(matching_files[matching_files == TRUE])
-        bai_files <- stringr::str_replace_all(bam_files, ".bam", ".bai")
+        bam_candidates <- files[grepl("\\.bam$", files, ignore.case = TRUE)]
+        bai_candidates <- files[grepl("\\.bai$", files, ignore.case = TRUE)]
+        index_files <- vapply(bam_candidates, function(bam_file) {
+            candidates <- c(
+                paste0(bam_file, ".bai"),
+                sub("\\.bam$", ".bai", bam_file, ignore.case = TRUE)
+            )
+            match_index <- match(tolower(candidates), tolower(bai_candidates))
+            if (all(is.na(match_index))) {
+                return(NA_character_)
+            }
+            bai_candidates[match_index[which(!is.na(match_index))[1]]]
+        }, character(1))
+
+        has_index <- !is.na(index_files)
+        bam_files <- unname(bam_candidates[has_index])
+        bai_files <- unname(index_files[has_index])
+        shiny::validate(
+            need(
+                length(bam_files) > 0,
+                message = "No BAM files with matching .bai indexes were found."
+            )
+        )
     }
 
 

--- a/ATACseqQCShniy/src/server-inputdata.R
+++ b/ATACseqQCShniy/src/server-inputdata.R
@@ -1,6 +1,8 @@
 observe({
     shinyjs::hide(selector = "a[data-value=\"fragmentsize_tab\"]")
     shinyjs::hide(selector = "a[data-value=\"nucleosomepositioning_tab\"]")
+    shinyjs::hide(selector = "a[data-value=\"nucleosomeprofiles_tab\"]")
+    shinyjs::hide(selector = "a[data-value=\"footprinting_tab\"]")
     shinyjs::hide(selector = "a[data-value=\"heatmap_tab\"]")
     shinyjs::hide(selector = "a[data-value=\"librarycomplexity_tab\"]")
 })
@@ -99,15 +101,24 @@ observeEvent(input$load_scratch_directory, {
 
 
 observeEvent(input$bs_genome_input, {
-    print(input$bs_genome_input)
-    if (input$bs_genome_input != "" & input$bs_genome_input != " ") {
-        print("input$bs_genome_input")
-        print(input$bs_genome_input)
-        check_and_load_bioc_package(input$bs_genome_input)
-        # library(input$bs_genome_input, character.only = T)
-        tx_db <- list("BSgenome.Hsapiens.UCSC.hg19" = c("TxDb.Hsapiens.UCSC.hg19.knownGene"))
+    if (!is.null(input$bs_genome_input) && nzchar(trimws(input$bs_genome_input))) {
+        genome_ready <- requireNamespace(
+            input$bs_genome_input,
+            quietly = TRUE
+        )
+        tx_package <- tx_db_list[[input$bs_genome_input]]
+        tx_ready <- length(tx_package) == 1L &&
+            requireNamespace(tx_package, quietly = TRUE)
+        if (!genome_ready || !tx_ready) {
+            shinyjs::disable("initQC")
+            showNotification(
+                "The selected genome is not installed in this ATACseqQC image.",
+                type = "error",
+                duration = NULL
+            )
+            return()
+        }
         shinyjs::enable("initQC")
-        # updateSelectInput(session, "tx_db_input", choices = tx_db[[input$bs_genome_input]])
     }
 })
 
@@ -221,7 +232,27 @@ input_files_reactive <- reactive({
 
     print(dir(base_dir))
 
-    bs_genome_db <- c(" " = " ", "Human(BSgenome.Hsapiens.UCSC.hg19)" = "BSgenome.Hsapiens.UCSC.hg19", "Mouse(BSgenome.Mmusculus.UCSC.mm10)" = "BSgenome.Mmusculus.UCSC.mm10", "ZebraFish(BSgenome.Drerio.UCSC.danRer11)" = "BSgenome.Drerio.UCSC.danRer11", "Worm(BSgenome.Celegans.UCSC.ce6)" = "BSgenome.Celegans.UCSC.ce6")
+    genome_labels <- c(
+        "Human (hg19)" = "BSgenome.Hsapiens.UCSC.hg19",
+        "Mouse (mm10)" = "BSgenome.Mmusculus.UCSC.mm10",
+        "Zebrafish (danRer11)" = "BSgenome.Drerio.UCSC.danRer11",
+        "C. elegans (ce11)" = "BSgenome.Celegans.UCSC.ce11"
+    )
+    installed <- vapply(
+        unname(genome_labels),
+        function(genome_package) {
+            tx_package <- tx_db_list[[genome_package]]
+            requireNamespace(genome_package, quietly = TRUE) &&
+                length(tx_package) == 1L &&
+                requireNamespace(tx_package, quietly = TRUE)
+        },
+        logical(1)
+    )
+    bs_genome_db <- c("Select a reference genome" = "", genome_labels[installed])
+    shiny::validate(need(
+        any(installed),
+        "No supported reference genome packages are installed in this image."
+    ))
     if (identical(input$data_file_type, "example_bam_file")) {
       updateSelectInput(session, "bs_genome_input", choices = bs_genome_db, selected = "BSgenome.Hsapiens.UCSC.hg19")
     } else {

--- a/ATACseqQCShniy/src/server-librarycomplexity.R
+++ b/ATACseqQCShniy/src/server-librarycomplexity.R
@@ -1,14 +1,12 @@
-output$plot_libcomplexity <- renderPlot({
-    print(input$sample_librarycomplexity)
-    print(my_values$samples_df[input$sample_librarycomplexity, "BamFile"])
-
+library_complexity_plot <- reactive({
+    req(input$sample_librarycomplexity, my_values$base_dir)
     bamfile <- file.path(my_values$base_dir, my_values$samples_df[input$sample_librarycomplexity, "BamFile"])
-    print(bamfile)
-    e <- estimateLibComplexity(readsDupFreq(bamfile))
-    # js$addStatusIcon("input_tab", "done")
-    e
+    estimateLibComplexity(readsDupFreq(bamfile))
 })
 
-text_reactive <- observeEvent(input$submit, {
-    print("submit")
-})
+output$plot_libcomplexity <- renderPlot(library_complexity_plot())
+register_publication_downloads(
+    output, "download_library_complexity",
+    function() paste0("atacseq-library-complexity-", input$sample_librarycomplexity),
+    library_complexity_plot, width = 8, height = 6
+)

--- a/ATACseqQCShniy/src/server-nucleosomepositioning.R
+++ b/ATACseqQCShniy/src/server-nucleosomepositioning.R
@@ -440,6 +440,32 @@ footprintDataReactive <- eventReactive(input$run_footprint_plots, {
     )
 }, ignoreInit = TRUE)
 
+observeEvent(input$run_nucleosome_plots, {
+    tryCatch(
+        nucleosomeDataReactive(),
+        error = function(error) {
+            showNotification(
+                paste("Nucleosome analysis failed:", conditionMessage(error)),
+                type = "error",
+                duration = NULL
+            )
+        }
+    )
+}, ignoreInit = TRUE)
+
+observeEvent(input$run_footprint_plots, {
+    tryCatch(
+        footprintDataReactive(),
+        error = function(error) {
+            showNotification(
+                paste("Footprint analysis failed:", conditionMessage(error)),
+                type = "error",
+                duration = NULL
+            )
+        }
+    )
+}, ignoreInit = TRUE)
+
 output$empty_txt_output <- renderText({
     inputDataReactive()
     ""

--- a/ATACseqQCShniy/src/server-nucleosomepositioning.R
+++ b/ATACseqQCShniy/src/server-nucleosomepositioning.R
@@ -1,504 +1,594 @@
 tx_db_list <- list(
-    "BSgenome.Hsapiens.UCSC.hg19" = c("TxDb.Hsapiens.UCSC.hg19.knownGene"),
-    "BSgenome.Mmusculus.UCSC.mm10" = c("TxDb.Mmusculus.UCSC.mm10.knownGene"),
-    "BSgenome.Drerio.UCSC.danRer11" = c("TxDb.Drerio.UCSC.danRer11.refGene"),
-    "BSgenome.Celegans.UCSC.ce11" = c("TxDb.Celegans.UCSC.ce11.refGene")
+    "BSgenome.Hsapiens.UCSC.hg19" = "TxDb.Hsapiens.UCSC.hg19.knownGene",
+    "BSgenome.Mmusculus.UCSC.mm10" = "TxDb.Mmusculus.UCSC.mm10.knownGene",
+    "BSgenome.Drerio.UCSC.danRer11" = "TxDb.Drerio.UCSC.danRer11.refGene",
+    "BSgenome.Celegans.UCSC.ce11" = "TxDb.Celegans.UCSC.ce11.refGene"
 )
-phast_cons_list <- list("BSgenome.Hsapiens.UCSC.hg19" = c("phastCons100way.UCSC.hg19"))
 
+atac_cache_root <- Sys.getenv(
+    "NASQAR_ATAC_CACHE_DIR",
+    unset = file.path(tempdir(check = TRUE), "ATACseqQC-cache")
+)
+dir.create(atac_cache_root, recursive = TRUE, showWarnings = FALSE)
 
+core_done <- reactiveVal(FALSE)
+nucleosome_done <- reactiveVal(FALSE)
+footprint_done <- reactiveVal(FALSE)
 
-bamfile_path <- reactive({
-    if (input$data_file_type == "example_bam_file") {
-        bamfile <- file.path(my_values$base_dir, my_values$samples_df[input$sel_sample_for_npositioning, "BamFile"])
-    } else {
-        bafiles <- input$bam_files
-    }
-})
-
-observeEvent(input$sel_sample_for_npositioning, {
-    # output$plot_vp
-    # output$plot_distanceDyad
-    # output$plot_featureAlignedHeatmap
-    # output$plot_nfr_score
-    # output$plot_Footprints
-    # output$plot_vp
-    # output$p
-})
-
-my_values$done <- FALSE
-output$task_done <- reactive({
-    if (my_values$done) {
-        return(TRUE)
-    } else {
-        return(FALSE)
-    }
-})
-
+output$task_done <- reactive(core_done())
+output$nucleosome_task_done <- reactive(nucleosome_done())
+output$footprint_task_done <- reactive(footprint_done())
 outputOptions(output, "task_done", suspendWhenHidden = FALSE)
+outputOptions(output, "nucleosome_task_done", suspendWhenHidden = FALSE)
+outputOptions(output, "footprint_task_done", suspendWhenHidden = FALSE)
 
+observeEvent(
+    list(
+        input$sel_sample_for_npositioning,
+        input$sel_chromosome,
+        input$bs_genome_input
+    ),
+    {
+        core_done(FALSE)
+        nucleosome_done(FALSE)
+        footprint_done(FALSE)
+    },
+    ignoreInit = TRUE
+)
+
+observeEvent(input$motif_value, {
+    footprint_done(FALSE)
+}, ignoreInit = TRUE)
+
+available_workers <- function(limit) {
+    requested <- suppressWarnings(as.integer(
+        Sys.getenv("SLURM_CPUS_PER_TASK", unset = "1")
+    ))
+    if (is.na(requested) || requested < 1L) {
+        requested <- 1L
+    }
+    max(1L, min(as.integer(limit), requested))
+}
+
+parallel_map <- function(values, callback, workers) {
+    if (workers > 1L && .Platform$OS.type == "unix") {
+        results <- parallel::mclapply(
+            values,
+            callback,
+            mc.cores = workers,
+            mc.preschedule = TRUE,
+            mc.set.seed = FALSE
+        )
+        failed <- vapply(results, inherits, logical(1), what = "try-error")
+        if (any(failed)) {
+            stop(as.character(results[[which(failed)[1]]]))
+        }
+        return(results)
+    }
+    lapply(values, callback)
+}
+
+with_null_device <- function(expression) {
+    grDevices::pdf(file = NULL)
+    on.exit(grDevices::dev.off(), add = TRUE)
+    force(expression)
+}
+
+write_cache <- function(value, path) {
+    temporary <- tempfile(pattern = "cache-", tmpdir = dirname(path))
+    saveRDS(value, temporary, compress = FALSE)
+    if (!file.rename(temporary, path)) {
+        unlink(temporary)
+        stop("Unable to save the ATACseqQC cache.")
+    }
+    value
+}
+
+cache_key_for <- function(stage, ...) {
+    digest::digest(
+        list(stage = stage, version = 2L, ...),
+        algo = "xxhash64"
+    )
+}
 
 inputDataReactive <- eventReactive(input$run_qc, {
-    print("inputDataReactive")
-    isolate({
-        my_values$done <- FALSE
-    })
+    req(
+        input$sel_sample_for_npositioning,
+        input$sel_chromosome,
+        input$bs_genome_input
+    )
 
-
+    shinyjs::disable("run_qc")
+    on.exit(shinyjs::enable("run_qc"), add = TRUE)
+    core_done(FALSE)
+    nucleosome_done(FALSE)
+    footprint_done(FALSE)
     js$addStatusIcon("nucleosomepositioning_tab", "loading")
 
-    
-    # library(tx_db_list[[input$bs_genome_input]], character.only = T)
-    check_and_load_bioc_package(tx_db_list[[input$bs_genome_input]])
+    withProgress(
+        message = "Calculating core ATAC-seq QC scores",
+        value = 0,
+        {
+            bamfile <- file.path(
+                my_values$base_dir,
+                my_values$samples_df[
+                    input$sel_sample_for_npositioning,
+                    "BamFile"
+                ]
+            )
+            bam_info <- file.info(bamfile)
+            validate(need(!is.na(bam_info$size), "The selected BAM file is unavailable."))
 
+            key <- cache_key_for(
+                "core",
+                normalizePath(bamfile, winslash = "/", mustWork = TRUE),
+                unname(bam_info$size),
+                as.numeric(bam_info$mtime),
+                input$bs_genome_input,
+                input$sel_chromosome
+            )
+            cache_dir <- file.path(atac_cache_root, key)
+            cache_file <- file.path(cache_dir, "core.rds")
+            shifted_bam <- file.path(cache_dir, "shifted.bam")
+            shifted_bai <- paste0(shifted_bam, ".bai")
+            dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
 
-    tags_integer_types <- input$sel_tag_integer_type
-    tags_char_types <- input$sel_tag_char_type
-    bamfile <- file.path(my_values$base_dir, my_values$samples_df[input$sel_sample_for_npositioning, "BamFile"])
+            tx_db_package <- tx_db_list[[input$bs_genome_input]]
+            validate(need(
+                !is.null(tx_db_package),
+                "No transcript annotation is configured for this genome."
+            ))
+            check_and_load_bioc_package(input$bs_genome_input)
+            check_and_load_bioc_package(tx_db_package)
 
-    # possibleTag <- list(
-    #     "integer" = c(
-    #         "AM", "AS", "CM", "CP", "FI", "H0", "H1", "H2",
-    #         "HI", "IH", "MQ", "NH", "NM", "OP", "PQ", "SM",
-    #         "TC", "UQ"
-    #     ),
-    #     "character" = c(
-    #         "BC", "BQ", "BZ", "CB", "CC", "CO", "CQ", "CR",
-    #         "CS", "CT", "CY", "E2", "FS", "LB", "MC", "MD",
-    #         "MI", "OA", "OC", "OQ", "OX", "PG", "PT", "PU",
-    #         "Q2", "QT", "QX", "R2", "RG", "RX", "SA", "TS",
-    #         "U2"
-    #     )
-    # )
-    # possibleTag <- list(
-    #      "integer" = tags_integer_types,
-    #      "character" = tags_char_types
+            if (
+                file.exists(cache_file) &&
+                file.exists(shifted_bam) &&
+                file.exists(shifted_bai)
+            ) {
+                incProgress(1, detail = "Loaded cached result")
+                cached <- readRDS(cache_file)
+                core_done(TRUE)
+                js$addStatusIcon("nucleosomepositioning_tab", "done")
+                return(cached)
+            }
 
-    # )
+            incProgress(0.1, detail = "Reading selected chromosome")
+            possible_tags <- combn(LETTERS, 2)
+            possible_tags <- c(
+                paste0(possible_tags[1, ], possible_tags[2, ]),
+                paste0(possible_tags[2, ], possible_tags[1, ])
+            )
+            bam_top_100 <- scanBam(
+                BamFile(bamfile, yieldSize = 100),
+                param = ScanBamParam(tag = possible_tags)
+            )[[1]]$tag
+            tags <- names(bam_top_100)[lengths(bam_top_100) > 0]
 
+            tx_db <- get(tx_db_package)
+            seqinformation <- seqinfo(tx_db)
+            chromosome <- input$sel_chromosome
+            validate(need(
+                chromosome %in% seqlevels(seqinformation),
+                "The chromosome is absent from the selected transcript database."
+            ))
+            chromosome_range <- as(seqinformation[chromosome], "GRanges")
+            alignments <- readBamFile(
+                bamfile,
+                tag = tags,
+                which = chromosome_range,
+                asMates = TRUE,
+                bigFile = TRUE
+            )
 
-    # print(bamfile)
-    # bam <- scanBam(BamFile(bamfile, yieldSize = 100),
-    #     param = ScanBamParam(tag = unlist(possibleTag))
-    # )
+            incProgress(0.2, detail = "Shifting alignments")
+            unlink(c(shifted_bam, shifted_bai))
+            shifted_alignments <- shiftGAlignmentsList(
+                alignments,
+                outbam = shifted_bam
+            )
 
+            transcripts_for_chromosome <- transcripts(tx_db)
+            transcripts_for_chromosome <- transcripts_for_chromosome[
+                as.character(seqnames(transcripts_for_chromosome)) == chromosome
+            ]
+            validate(need(
+                length(transcripts_for_chromosome) > 0,
+                "No transcripts were found for the selected chromosome."
+            ))
 
-    # Create a BamFile object
-    # bam <- BamFile(bamfile,yieldSize = 100)
+            incProgress(0.25, detail = "Calculating PT, NFR, and TSSE scores")
+            score_names <- c("pt", "nfr", "tsse")
+            score_workers <- available_workers(length(score_names))
+            score_results <- parallel_map(
+                score_names,
+                function(score_name) {
+                    with_null_device(
+                        switch(
+                            score_name,
+                            pt = PTscore(
+                                shifted_alignments,
+                                transcripts_for_chromosome
+                            ),
+                            nfr = NFRscore(
+                                shifted_alignments,
+                                transcripts_for_chromosome
+                            ),
+                            tsse = TSSEscore(
+                                shifted_alignments,
+                                transcripts_for_chromosome
+                            )
+                        )
+                    )
+                },
+                workers = score_workers
+            )
+            names(score_results) <- score_names
 
-    # Get the number of records in the BAM file
-    # record_count <-countBam(bam)$records
-
-    # Print the number of records
-    # print(record_count)
-    # print(record_count)
-    # updateNumericInput(session,"record_count_value", label=paste0('Records(max ',record_count, ')'), max = record_count )
-
-    ## bamfile tags to be read in
-    possibleTag <- combn(LETTERS, 2)
-    possibleTag <- c(
-        paste0(possibleTag[1, ], possibleTag[2, ]),
-        paste0(possibleTag[2, ], possibleTag[1, ])
+            result <- list(
+                key = key,
+                cache_dir = cache_dir,
+                bamfile = bamfile,
+                shifted_bam = shifted_bam,
+                chromosome_range = chromosome_range,
+                chromosome = chromosome,
+                genome_package = input$bs_genome_input,
+                transcript_package = tx_db_package,
+                alignments = shifted_alignments,
+                transcripts = transcripts_for_chromosome,
+                pt = score_results$pt,
+                nfr = score_results$nfr,
+                tsse = score_results$tsse,
+                score_workers = score_workers
+            )
+            incProgress(0.2, detail = "Saving reusable result")
+            write_cache(result, cache_file)
+            core_done(TRUE)
+            js$addStatusIcon("nucleosomepositioning_tab", "done")
+            result
+        }
     )
-    bamTop100 <- scanBam(BamFile(bamfile, yieldSize = 100),
-        param = ScanBamParam(tag = possibleTag)
-    )[[1]]$tag
-    ntags <- names(bamTop100)[lengths(bamTop100) > 0]
+}, ignoreInit = TRUE)
 
-    print(ntags)
+nucleosomeDataReactive <- eventReactive(input$run_nucleosome_plots, {
+    core <- inputDataReactive()
+    req(core)
 
-    # library(TxDb.Hsapiens.UCSC.hg19.knownGene)
-    ## if you don't have an available TxDb, please refer
-    ## GenomicFeatures::makeTxDbFromGFF to create one from gff3 or gtf file.
-    seqlev <- input$sel_chromosome ## subsample data for quick run
-    txb <- tx_db_list[[input$bs_genome_input]]
-    
-    seqinformation <- seqinfo(get(txb))
-    as(seqinformation[input$sel_chromosome], "GRanges")
-    # seqinformation <- seqinfo(TxDb.Hsapiens.UCSC.hg19.knownGene)
-    print(seqinformation)
+    shinyjs::disable("run_nucleosome_plots")
+    on.exit(shinyjs::enable("run_nucleosome_plots"), add = TRUE)
+    nucleosome_done(FALSE)
 
-    which <- as(seqinformation[seqlev], "GRanges")
-    my_values$GRanges <- which
-    gal <- readBamFile(bamfile, tag = ntags, which = which, asMates = TRUE, bigFile = TRUE)
+    withProgress(
+        message = "Calculating nucleosome distributions",
+        value = 0,
+        {
+            cache_file <- file.path(core$cache_dir, "nucleosome.rds")
+            required_bams <- file.path(
+                core$cache_dir,
+                c(
+                    "NucleosomeFree.bam",
+                    "mononucleosome.bam",
+                    "dinucleosome.bam",
+                    "trinucleosome.bam"
+                )
+            )
+            if (
+                file.exists(cache_file) &&
+                all(file.exists(required_bams))
+            ) {
+                incProgress(1, detail = "Loaded cached result")
+                cached <- readRDS(cache_file)
+                nucleosome_done(TRUE)
+                return(cached)
+            }
 
-    outPath <- tempdir()
-    outPath <- paste0(file.path(outPath, input$sel_sample_for_npositioning))
-    dir.create(outPath)
+            genome_name <- strsplit(core$genome_package, ".", fixed = TRUE)[[1]][2]
+            genome <- get(genome_name)
+            incProgress(0.25, detail = "Splitting alignments by fragment size")
+            split_alignments <- splitGAlignmentsByCut(
+                core$alignments,
+                txs = core$transcripts,
+                genome = genome,
+                outPath = core$cache_dir
+            )
 
-    files <- list.files(outPath, full.names = T, recursive = TRUE)
-    file.remove(files)
+            tss <- unique(promoters(core$transcripts, upstream = 0, downstream = 1))
+            library_size <- estLibSize(required_bams)
+            n_tile <- 101L
+            upstream <- 1010L
+            downstream <- 1010L
 
-    shiftedBamfile <- file.path(outPath, "shifted.bam")
-    gal1 <- shiftGAlignmentsList(gal, outbam = shiftedBamfile)
+            incProgress(0.35, detail = "Calculating TSS-aligned signals")
+            tss_signals <- enrichedFragments(
+                gal = split_alignments[c(
+                    "NucleosomeFree",
+                    "mononucleosome",
+                    "dinucleosome",
+                    "trinucleosome"
+                )],
+                TSS = tss,
+                librarySize = library_size,
+                seqlev = core$chromosome,
+                TSS.filter = 0.5,
+                n.tile = n_tile,
+                upstream = upstream,
+                downstream = downstream
+            )
+            log2_signals <- lapply(tss_signals, function(signal) log2(signal + 1))
+            centered_tss <- reCenterPeaks(tss, width = upstream + downstream)
 
-    print(dir(outPath))
+            incProgress(0.25, detail = "Normalizing distributions")
+            distribution <- with_null_device(
+                featureAlignedDistribution(
+                    tss_signals,
+                    centered_tss,
+                    zeroAt = 0.5,
+                    n.tile = n_tile,
+                    type = "l",
+                    ylab = "Averaged coverage"
+                )
+            )
+            range_01 <- function(values) {
+                value_range <- range(values, na.rm = TRUE)
+                if (!all(is.finite(value_range)) || diff(value_range) == 0) {
+                    return(rep(0, length(values)))
+                }
+                (values - value_range[1]) / diff(value_range)
+            }
+            distribution <- apply(distribution, 2, range_01)
 
-
-    # Promoter/Transcript body (PT) score
-    # PT score is calculated as the coverage of promoter divided by the coverage of its transcript body.
-    # PT score will show if the signal is enriched in promoters.
-
-    tx_db <- tx_db_list[[input$bs_genome_input]]
-    #library(tx_db, character.only = T)
-    check_and_load_bioc_package(tx_db)
-    txs <- transcripts(get(tx_db))
-    my_values$pt <- PTscore(gal1, txs)
-    # plot will be called under renderPlot
-    # plot(pt$log2meanCoverage, pt$PT_score,
-    #  xlab="log2 mean coverage",
-    #  ylab="Promoter vs Transcript")
-
-
-    # Nucleosome Free Regions (NFR) score
-    my_values$nfr <- NFRscore(gal1, txs)
-    # plot will be called under renderPlot
-    # plot(nfr$log2meanCoverage, nfr$NFR_score,
-    #  xlab="log2 mean coverage",
-    #  ylab="Nucleosome Free Regions score",
-    #  main="NFRscore for 200bp flanking TSSs",
-    #  xlim=c(-10, 0), ylim=c(-5, 5))
-
-    ####################################################################################################
-    # Transcription Start Site (TSS) Enrichment Score
-    # TSS enrichment score is a raio between aggregate distribution of reads centered on TSSs and that
-    # flanking the corresponding TSSs. TSS score = the depth of
-    # TSS (each 100bp window within 1000 bp each side) / the depth of end flanks (100bp each end).
-    # TSSE score = max(mean(TSS score in each window)). TSS enrichment score is calculated according
-    # to the definition at https://www.encodeproject.org/data-standards/terms/#enrichment.
-    # Transcription start site (TSS) enrichment values are dependent on the reference files used;
-    # cutoff values for high quality data are listed in the following table from https://www.encodeproject.org/atac-seq/.
-    ####################################################################################################
-
-    my_values$tsse <- TSSEscore(gal1, txs)
-    # plot will be called under renderPlot
-    # plot(100*(-9:10-.5), tsse$values, type="b",
-    #  xlab="distance to TSS",
-    #  ylab="aggregate TSS score")
-
-    # =======================================================
-    # Split reads
-    # =======================================================
-
-    txs1 <- txs[seqnames(txs) %in% input$sel_chromosome]
-    genome <- get(unlist(strsplit(input$bs_genome_input, "\\."))[[2]])
-    ## split the reads into NucleosomeFree, mononucleosome,
-    ## dinucleosome and trinucleosome.
-    ## and save the binned alignments into bam files.
-    objs <- splitGAlignmentsByCut(gal1,
-        txs = txs1, genome = genome, outPath = outPath
-        # conservation = phastCons100way.UCSC.hg19
+            result <- list(
+                split_alignments = split_alignments,
+                bamfiles = required_bams,
+                tss = tss,
+                tss_signals = tss_signals,
+                log2_signals = log2_signals,
+                centered_tss = centered_tss,
+                distribution = distribution,
+                n_tile = n_tile,
+                upstream = upstream,
+                downstream = downstream
+            )
+            incProgress(0.15, detail = "Saving reusable result")
+            write_cache(result, cache_file)
+            nucleosome_done(TRUE)
+            result
+        }
     )
+}, ignoreInit = TRUE)
 
+footprintDataReactive <- eventReactive(input$run_footprint_plots, {
+    core <- inputDataReactive()
+    req(core, input$motif_value)
 
-    ####################################################################################################
-    # Heatmap and coverage curve for nucleosome positions
-    # By averaging the signal across all active TSSs, we should observe that nucleosome-free
-    # fragments are enriched at the TSSs, whereas the nucleosome-bound fragments should be
-    # enriched both upstream and downstream of the active TSSs and display characteristic phasing
-    # of upstream and downstream nucleosomes. Because ATAC-seq reads are concentrated at regions
-    # of open chromatin, users should see a strong nucleosome signal at the +1 nucleosome, but
-    # the signal decreases at the +2, +3 and +4 nucleosomes.
-    ####################################################################################################
+    shinyjs::disable("run_footprint_plots")
+    on.exit(shinyjs::enable("run_footprint_plots"), add = TRUE)
+    footprint_done(FALSE)
 
-    my_values$outPath <- outPath
-    bamfile <- my_values$bamfile
-    outPath <- my_values$outPath
+    withProgress(
+        message = "Calculating motif footprinting",
+        value = 0,
+        {
+            motif_key <- cache_key_for(
+                "footprint",
+                core$key,
+                trimws(input$motif_value)
+            )
+            footprint_dir <- file.path(core$cache_dir, motif_key)
+            dir.create(footprint_dir, recursive = TRUE, showWarnings = FALSE)
+            cache_file <- file.path(footprint_dir, "footprint.rds")
+            footprint_png <- file.path(footprint_dir, "footprint.png")
+            vplot_png <- file.path(footprint_dir, "vplot.png")
+            if (
+                file.exists(cache_file) &&
+                file.exists(footprint_png) &&
+                file.exists(vplot_png)
+            ) {
+                incProgress(1, detail = "Loaded cached result")
+                cached <- readRDS(cache_file)
+                footprint_done(TRUE)
+                return(cached)
+            }
 
-    bamfiles <- file.path(
-        outPath,
-        c(
-            "NucleosomeFree.bam",
-            "mononucleosome.bam",
-            "dinucleosome.bam",
-            "trinucleosome.bam"
-        )
+            motif <- as.list(query(MotifDb, trimws(input$motif_value)))
+            validate(need(length(motif) > 0, "No matching motif was found."))
+            genome_name <- strsplit(core$genome_package, ".", fixed = TRUE)[[1]][2]
+            genome <- get(genome_name)
+
+            incProgress(0.2, detail = "Calculating footprint profile")
+            grDevices::png(footprint_png, width = 1200, height = 800, res = 120)
+            footprint_signals <- tryCatch(
+                factorFootprints(
+                    core$shifted_bam,
+                    pfm = motif[[1]],
+                    genome = genome,
+                    min.score = "90%",
+                    seqlev = core$chromosome,
+                    upstream = 100,
+                    downstream = 100
+                ),
+                finally = grDevices::dev.off()
+            )
+
+            incProgress(0.45, detail = "Calculating fragment V-plot")
+            grDevices::png(vplot_png, width = 1200, height = 800, res = 120)
+            vplot <- tryCatch(
+                vPlot(
+                    core$shifted_bam,
+                    bindingSites = footprint_signals$bindingSites,
+                    genome = genome,
+                    seqlev = core$chromosome,
+                    upstream = 200,
+                    downstream = 200,
+                    ylim = c(30, 250),
+                    bandwidth = c(2, 1)
+                ),
+                finally = grDevices::dev.off()
+            )
+
+            result <- list(
+                signals = footprint_signals,
+                vplot = vplot,
+                footprint_png = footprint_png,
+                vplot_png = vplot_png
+            )
+            incProgress(0.25, detail = "Saving reusable result")
+            write_cache(result, cache_file)
+            footprint_done(TRUE)
+            result
+        }
     )
-
-    TSS <- promoters(txs, upstream = 0, downstream = 1)
-    TSS <- unique(TSS)
-    ## estimate the library size for normalization
-    (librarySize <- estLibSize(bamfiles))
-    ## splited/NucleosomeFree.bam splited/mononucleosome.bam
-    ##                      34276                       1933
-    ##   splited/dinucleosome.bam  splited/trinucleosome.bam
-    ##                       1871                        403
-
-    NTILE <- 101 # Not sure chosen value?
-    dws <- ups <- 1010 # Not sure chosen value?
-    tss_sigs <- enrichedFragments(
-        gal = objs[c(
-            "NucleosomeFree",
-            "mononucleosome",
-            "dinucleosome",
-            "trinucleosome"
-        )],
-        TSS = TSS,
-        librarySize = librarySize,
-        seqlev = seqlev,
-        TSS.filter = 0.5,
-        n.tile = NTILE,
-        upstream = ups,
-        downstream = dws
-    )
-    ## log2 transformed signals
-    tss_sigs.log2 <- lapply(tss_sigs, function(.ele) log2(.ele + 1))
-    tss_center_peaks <- reCenterPeaks(TSS, width = ups + dws)
-    my_values$tss_center_peaks <- tss_center_peaks
-
-
-    ## get signals normalized for nucleosome-free and nucleosome-bound regions.
-    out <- featureAlignedDistribution(tss_sigs,
-        tss_center_peaks,
-        zeroAt = .5, n.tile = NTILE, type = "l",
-        ylab = "Averaged coverage"
-    )
-
-    range01 <- function(x) {
-        (x - min(x)) / (max(x) - min(x))
-    }
-    out <- apply(out, 2, range01)
-    my_values$out <- out
-
-    ####################################################################################################
-    # plot Footprints
-    # ATAC-seq footprints infer factor occupancy genome-wide. The factorFootprints function uses matchPWM
-    # to predict the binding sites using the input position weight matrix (PWM). Then it calculates and plots
-    # the accumulated coverage for those binding sites to show the status of the occupancy genome-wide.
-    # Unlike CENTIPEDE4, the footprints generated here do not take the conservation (PhyloP) into consideration.
-    # factorFootprints function could also accept the binding sites as a GRanges object.
-    ####################################################################################################
-
-    CTCF <- query(MotifDb, c(input$motif_value))
-    CTCF <- as.list(CTCF)
-    print(CTCF[[1]], digits = 2)
-
-
-
-    # library(BSgenome.Hsapiens.UCSC.hg19)
-    # library(input$bs_genome_input, character.only = T)
-
-
-    genome <- get(unlist(strsplit(input$bs_genome_input, "\\."))[[2]])
-
-
-
-
-
-    js$addStatusIcon("nucleosomepositioning_tab", "done")
-    isolate({
-        my_values$done <- TRUE
-    })
-
-    return(list("gal1" = gal1, "txs" = txs, "objs" = objs, "tss_sigs" = tss_sigs, "tss_sigs.log2" = tss_sigs.log2, "TSS" = TSS, "dws" = dws, "ups" = ups, "NTILE" = NTILE, "genome" = genome, "CTCF" = CTCF))
-})
+}, ignoreInit = TRUE)
 
 output$empty_txt_output <- renderText({
     inputDataReactive()
-
     ""
 })
 
-
-
 output$plot_pt_score <- renderPlot({
-    # files will be output into outPath
-    inputDataReactive()
-    pt <- my_values$pt
-    plot(pt$log2meanCoverage, pt$PT_score,
+    pt <- inputDataReactive()$pt
+    plot(
+        pt$log2meanCoverage,
+        pt$PT_score,
         xlab = "log2 mean coverage",
         ylab = "Promoter vs Transcript"
     )
 })
 
-
 output$plot_nfr_score <- renderPlot({
-    inputDataReactive()
-    nfr <- my_values$nfr
-    plot(nfr$log2meanCoverage, nfr$NFR_score,
+    nfr <- inputDataReactive()$nfr
+    plot(
+        nfr$log2meanCoverage,
+        nfr$NFR_score,
         xlab = "log2 mean coverage",
         ylab = "Nucleosome Free Regions score",
-        main = "NFRscore for 200bp flanking TSSs",
-        xlim = c(-10, 0), ylim = c(-5, 5)
+        main = "NFR score for 200 bp flanking TSSs",
+        xlim = c(-10, 0),
+        ylim = c(-5, 5)
     )
 })
 
-
 output$plot_tssre_score <- renderPlot({
-    inputDataReactive()
-    tsse <- my_values$tsse
-    plot(100 * (-9:10 - .5), tsse$values,
+    tsse <- inputDataReactive()$tsse
+    plot(
+        100 * (-9:10 - 0.5),
+        tsse$values,
         type = "b",
         xlab = "distance to TSS",
         ylab = "aggregate TSS score"
     )
 })
 
-
 output$plotCumulativePercentage <- renderPlot({
-    inputDataReactive()
-    outPath <- my_values$outPath
-    bamfiles <- file.path(
-        outPath,
-        c(
-            "NucleosomeFree.bam",
-            "mononucleosome.bam",
-            "dinucleosome.bam",
-            "trinucleosome.bam"
-        )
+    core <- inputDataReactive()
+    nucleosome <- nucleosomeDataReactive()
+    cumulativePercentage(
+        nucleosome$bamfiles[1:2],
+        core$chromosome_range
     )
-    # print(bamfiles)
-    ## Plot the cumulative percentage of tag allocation in nucleosome-free
-    ## and mononucleosome bam files.
-    # cumulativePercentage(bamfiles[1:2], as(seqinformation[input$sel_chromosome], "GRanges"))
-    cumulativePercentage(bamfiles[1:2], my_values$GRanges)
 })
 
 output$plot_tss_featureAlignedHeatmap <- renderPlot({
-    tss_sigs.log2 <- inputDataReactive()$tss_sigs.log2
-    NTILE <- inputDataReactive()$NTILE
-    tss_center_peaks <- my_values$tss_center_peaks
-
-    featureAlignedHeatmap(tss_sigs.log2, tss_center_peaks, zeroAt = .5, n.tile = NTILE)
-
-
-
-    # featureAlignedHeatmap(sigs$signal,
-    #         feature.gr=reCenterPeaks(sigs$bindingSites,
-    #                                 width=200+width(sigs$bindingSites[1])),
-    #         annoMcols="score",
-    #         sortBy="score",
-    #         n.tile=ncol(sigs$signal[[1]]))
+    nucleosome <- nucleosomeDataReactive()
+    featureAlignedHeatmap(
+        nucleosome$log2_signals,
+        nucleosome$centered_tss,
+        zeroAt = 0.5,
+        n.tile = nucleosome$n_tile
+    )
 })
 
-
-
 output$plot_signals <- renderPlot({
-    inputDataReactive()
-    out <- my_values$out
-    matplot(out,
-        type = "l", xaxt = "n",
+    distribution <- nucleosomeDataReactive()$distribution
+    matplot(
+        distribution,
+        type = "l",
+        xaxt = "n",
         xlab = "Position (bp)",
         ylab = "Fraction of signal"
     )
-    axis(1,
+    axis(
+        1,
         at = seq(0, 100, by = 10) + 1,
-        labels = c("-1K", seq(-800, 800, by = 200), "1K"), las = 2
+        labels = c("-1K", seq(-800, 800, by = 200), "1K"),
+        las = 2
     )
     abline(v = seq(0, 100, by = 10) + 1, lty = 2, col = "gray")
 })
 
-
-
-output$plot_Footprints <- renderPlot({
-    isolate({
-        seqlev <- input$sel_chromosome
-    })
-
-    CTCF <- inputDataReactive()$CTCF
-    genome <- inputDataReactive()$genome
-
-    outPath <- my_values$outPath
-    shiftedBamfile <- file.path(outPath, "shifted.bam")
-
-    my_values$binding_sites_sigs <- factorFootprints(shiftedBamfile,
-        pfm = CTCF[[1]],
-        genome = genome, ## Don't have a genome? ask ?factorFootprints for help
-        min.score = "90%", seqlev = seqlev,
-        upstream = 100, downstream = 100
+output$plot_Footprints <- renderImage({
+    result <- footprintDataReactive()
+    list(
+        src = result$footprint_png,
+        contentType = "image/png",
+        alt = "DNA-binding factor footprint"
     )
-})
-
+}, deleteFile = FALSE)
 
 output$plot_binding_sites_featureAlignedHeatmap <- renderPlot({
-    inputDataReactive()
-    sigs <- my_values$binding_sites_sigs
-    NTILE <- inputDataReactive()$NTILE
-    tss_center_peaks <- my_values$tss_center_peaks
-
-    
-    featureAlignedHeatmap(sigs$signal,
-            feature.gr=reCenterPeaks(sigs$bindingSites,
-                                    width=200+width(sigs$bindingSites[1])),
-            annoMcols="score",
-            sortBy="score",
-            n.tile=ncol(sigs$signal[[1]]))
-})
-
-
-
-
-output$plot_vp <- renderPlot({
-    isolate({
-        seqlev <- input$sel_chromosome
-    })
-    inputDataReactive()
-
-    outPath <- my_values$outPath
-    shiftedBamfile <- file.path(outPath, "shifted.bam")
-
-    CTCF <- inputDataReactive()$CTCF
-    genome <- inputDataReactive()$genome
-    my_values$vp <- vPlot(shiftedBamfile,
-        pfm = CTCF[[1]],
-        genome = genome, min.score = "90%", seqlev = seqlev,
-        upstream = 200, downstream = 200,
-        ylim = c(30, 250), bandwidth = c(2, 1)
+    signals <- footprintDataReactive()$signals
+    featureAlignedHeatmap(
+        signals$signal,
+        feature.gr = reCenterPeaks(
+            signals$bindingSites,
+            width = 200 + width(signals$bindingSites[1])
+        ),
+        annoMcols = "score",
+        sortBy = "score",
+        n.tile = ncol(signals$signal[[1]])
     )
 })
 
+output$plot_vp <- renderImage({
+    result <- footprintDataReactive()
+    list(
+        src = result$vplot_png,
+        contentType = "image/png",
+        alt = "ATAC-seq fragment V-plot"
+    )
+}, deleteFile = FALSE)
+
 output$plot_distanceDyad <- renderPlot({
-    inputDataReactive()
-    vp <- my_values$vp
-    distanceDyad(vp, pch = 20, cex = .5)
+    distanceDyad(footprintDataReactive()$vplot, pch = 20, cex = 0.5)
 })
-
-
 
 output$bamfilesTable <- renderDataTable(
     {
-        inputDataReactive()
-        files <- list.files(my_values$outPath, full.names = T, recursive = TRUE)
-        df <- data.frame(Filename=basename(files))
-        DT::datatable(df, options = list(scrollX = TRUE))
+        files <- list.files(
+            inputDataReactive()$cache_dir,
+            pattern = "\\.bam(\\.bai)?$",
+            full.names = TRUE
+        )
+        DT::datatable(
+            data.frame(Filename = basename(files)),
+            options = list(scrollX = TRUE)
+        )
     },
     options = list(scrollX = TRUE)
 )
 
-  output$download_bamfiles_btn <- downloadHandler(
-    filename = function(){
-      paste("bamfiles_", Sys.Date(), ".zip", sep = "")
+output$download_bamfiles_btn <- downloadHandler(
+    filename = function() {
+        paste("bamfiles_", Sys.Date(), ".zip", sep = "")
     },
-    content = function(file){
-      
-      temp_directory <- file.path(tempdir(), as.integer(Sys.time()))
-      dir.create(temp_directory)
-      files <- list.files(my_values$outPath, full.names = T, recursive = TRUE)
-      files <- files[input$bamfilesTable_rows_selected]
-      print(files)
-      print(input$bamfilesTable_rows_selected)
-    #   reactiveValuesToList(to_download) %>%
-    #     imap(function(x,y){
-    #       if(!is.null(x)){
-    #         file_name <- glue("{y}_data.csv")
-    #         readr::write_csv(x, file.path(temp_directory, file_name))
-    #       }
-    #     })
-      
-      file.copy(files, temp_directory)
-    #   for(f in files){
-    #     file_copy(f, paste0(temp_directory, basename(f)))
-    #   }
-     
-      zip::zip(
-        zipfile = file,
-        files = dir(temp_directory),
-        root = temp_directory
-      )
-      
-      
-      
+    content = function(file) {
+        temporary_directory <- tempfile(pattern = "bam-download-")
+        dir.create(temporary_directory)
+        files <- list.files(
+            inputDataReactive()$cache_dir,
+            pattern = "\\.bam(\\.bai)?$",
+            full.names = TRUE
+        )
+        selected <- input$bamfilesTable_rows_selected
+        if (length(selected) > 0) {
+            files <- files[selected]
+        }
+        file.copy(files, temporary_directory)
+        zip::zip(
+            zipfile = file,
+            files = dir(temporary_directory),
+            root = temporary_directory
+        )
     },
     contentType = "application/zip"
-    
-  )
+)

--- a/ATACseqQCShniy/src/server-nucleosomepositioning.R
+++ b/ATACseqQCShniy/src/server-nucleosomepositioning.R
@@ -14,6 +14,8 @@ dir.create(atac_cache_root, recursive = TRUE, showWarnings = FALSE)
 core_done <- reactiveVal(FALSE)
 nucleosome_done <- reactiveVal(FALSE)
 footprint_done <- reactiveVal(FALSE)
+nucleosome_result <- reactiveVal(NULL)
+footprint_result <- reactiveVal(NULL)
 
 output$task_done <- reactive(core_done())
 output$nucleosome_task_done <- reactive(nucleosome_done())
@@ -21,6 +23,17 @@ output$footprint_task_done <- reactive(footprint_done())
 outputOptions(output, "task_done", suspendWhenHidden = FALSE)
 outputOptions(output, "nucleosome_task_done", suspendWhenHidden = FALSE)
 outputOptions(output, "footprint_task_done", suspendWhenHidden = FALSE)
+
+observe({
+    if (isTRUE(core_done())) {
+        shinyjs::show(selector = "a[data-value=\"nucleosomeprofiles_tab\"]")
+        shinyjs::show(selector = "a[data-value=\"footprinting_tab\"]")
+        js$addStatusIcon("nucleosomeprofiles_tab", "next")
+    } else {
+        shinyjs::hide(selector = "a[data-value=\"nucleosomeprofiles_tab\"]")
+        shinyjs::hide(selector = "a[data-value=\"footprinting_tab\"]")
+    }
+})
 
 observeEvent(
     list(
@@ -32,12 +45,15 @@ observeEvent(
         core_done(FALSE)
         nucleosome_done(FALSE)
         footprint_done(FALSE)
+        nucleosome_result(NULL)
+        footprint_result(NULL)
     },
     ignoreInit = TRUE
 )
 
 observeEvent(input$motif_value, {
     footprint_done(FALSE)
+    footprint_result(NULL)
 }, ignoreInit = TRUE)
 
 available_workers <- function(limit) {
@@ -250,13 +266,14 @@ inputDataReactive <- eventReactive(input$run_qc, {
     )
 }, ignoreInit = TRUE)
 
-nucleosomeDataReactive <- eventReactive(input$run_nucleosome_plots, {
+calculateNucleosomeData <- function() {
     core <- inputDataReactive()
     req(core)
 
     shinyjs::disable("run_nucleosome_plots")
     on.exit(shinyjs::enable("run_nucleosome_plots"), add = TRUE)
     nucleosome_done(FALSE)
+    js$addStatusIcon("nucleosomeprofiles_tab", "loading")
 
     withProgress(
         message = "Calculating nucleosome distributions",
@@ -279,6 +296,7 @@ nucleosomeDataReactive <- eventReactive(input$run_nucleosome_plots, {
                 incProgress(1, detail = "Loaded cached result")
                 cached <- readRDS(cache_file)
                 nucleosome_done(TRUE)
+                js$addStatusIcon("nucleosomeprofiles_tab", "done")
                 return(cached)
             }
 
@@ -352,18 +370,20 @@ nucleosomeDataReactive <- eventReactive(input$run_nucleosome_plots, {
             incProgress(0.15, detail = "Saving reusable result")
             write_cache(result, cache_file)
             nucleosome_done(TRUE)
+            js$addStatusIcon("nucleosomeprofiles_tab", "done")
             result
         }
     )
-}, ignoreInit = TRUE)
+}
 
-footprintDataReactive <- eventReactive(input$run_footprint_plots, {
+calculateFootprintData <- function() {
     core <- inputDataReactive()
     req(core, input$motif_value)
 
     shinyjs::disable("run_footprint_plots")
     on.exit(shinyjs::enable("run_footprint_plots"), add = TRUE)
     footprint_done(FALSE)
+    js$addStatusIcon("footprinting_tab", "loading")
 
     withProgress(
         message = "Calculating motif footprinting",
@@ -377,8 +397,8 @@ footprintDataReactive <- eventReactive(input$run_footprint_plots, {
             footprint_dir <- file.path(core$cache_dir, motif_key)
             dir.create(footprint_dir, recursive = TRUE, showWarnings = FALSE)
             cache_file <- file.path(footprint_dir, "footprint.rds")
-            footprint_png <- file.path(footprint_dir, "footprint.png")
-            vplot_png <- file.path(footprint_dir, "vplot.png")
+            footprint_png <- file.path(footprint_dir, "footprint-300dpi.png")
+            vplot_png <- file.path(footprint_dir, "vplot-300dpi.png")
             if (
                 file.exists(cache_file) &&
                 file.exists(footprint_png) &&
@@ -387,6 +407,7 @@ footprintDataReactive <- eventReactive(input$run_footprint_plots, {
                 incProgress(1, detail = "Loaded cached result")
                 cached <- readRDS(cache_file)
                 footprint_done(TRUE)
+                js$addStatusIcon("footprinting_tab", "done")
                 return(cached)
             }
 
@@ -396,7 +417,7 @@ footprintDataReactive <- eventReactive(input$run_footprint_plots, {
             genome <- get(genome_name)
 
             incProgress(0.2, detail = "Calculating footprint profile")
-            grDevices::png(footprint_png, width = 1200, height = 800, res = 120)
+            grDevices::png(footprint_png, width = 3000, height = 2000, res = 300)
             footprint_signals <- tryCatch(
                 factorFootprints(
                     core$shifted_bam,
@@ -411,7 +432,7 @@ footprintDataReactive <- eventReactive(input$run_footprint_plots, {
             )
 
             incProgress(0.45, detail = "Calculating fragment V-plot")
-            grDevices::png(vplot_png, width = 1200, height = 800, res = 120)
+            grDevices::png(vplot_png, width = 3000, height = 2000, res = 300)
             vplot <- tryCatch(
                 vPlot(
                     core$shifted_bam,
@@ -435,17 +456,33 @@ footprintDataReactive <- eventReactive(input$run_footprint_plots, {
             incProgress(0.25, detail = "Saving reusable result")
             write_cache(result, cache_file)
             footprint_done(TRUE)
+            js$addStatusIcon("footprinting_tab", "done")
             result
         }
     )
-}, ignoreInit = TRUE)
+}
+
+nucleosomeDataReactive <- reactive({
+    req(nucleosome_result())
+    nucleosome_result()
+})
+
+footprintDataReactive <- reactive({
+    req(footprint_result())
+    footprint_result()
+})
 
 observeEvent(input$run_nucleosome_plots, {
     tryCatch(
-        nucleosomeDataReactive(),
+        nucleosome_result(calculateNucleosomeData()),
         error = function(error) {
+            js$addStatusIcon("nucleosomeprofiles_tab", "fail")
+            message <- conditionMessage(error)
+            if (!nzchar(message)) {
+                message <- "Run core QC before starting nucleosome analysis."
+            }
             showNotification(
-                paste("Nucleosome analysis failed:", conditionMessage(error)),
+                paste("Nucleosome analysis failed:", message),
                 type = "error",
                 duration = NULL
             )
@@ -455,10 +492,15 @@ observeEvent(input$run_nucleosome_plots, {
 
 observeEvent(input$run_footprint_plots, {
     tryCatch(
-        footprintDataReactive(),
+        footprint_result(calculateFootprintData()),
         error = function(error) {
+            js$addStatusIcon("footprinting_tab", "fail")
+            message <- conditionMessage(error)
+            if (!nzchar(message)) {
+                message <- "Run core QC and enter a motif before footprint analysis."
+            }
             showNotification(
-                paste("Footprint analysis failed:", conditionMessage(error)),
+                paste("Footprint analysis failed:", message),
                 type = "error",
                 duration = NULL
             )
@@ -471,7 +513,25 @@ output$empty_txt_output <- renderText({
     ""
 })
 
-output$plot_pt_score <- renderPlot({
+output$nucleosome_context <- renderText({
+    core <- inputDataReactive()
+    paste(
+        tools::file_path_sans_ext(basename(core$bamfile)),
+        "on",
+        core$chromosome
+    )
+})
+
+output$footprint_context <- renderText({
+    core <- inputDataReactive()
+    paste(
+        tools::file_path_sans_ext(basename(core$bamfile)),
+        "on",
+        core$chromosome
+    )
+})
+
+pt_score_plot <- reactive({
     pt <- inputDataReactive()$pt
     plot(
         pt$log2meanCoverage,
@@ -481,7 +541,7 @@ output$plot_pt_score <- renderPlot({
     )
 })
 
-output$plot_nfr_score <- renderPlot({
+nfr_score_plot <- reactive({
     nfr <- inputDataReactive()$nfr
     plot(
         nfr$log2meanCoverage,
@@ -494,7 +554,7 @@ output$plot_nfr_score <- renderPlot({
     )
 })
 
-output$plot_tssre_score <- renderPlot({
+tss_enrichment_plot <- reactive({
     tsse <- inputDataReactive()$tsse
     plot(
         100 * (-9:10 - 0.5),
@@ -505,7 +565,7 @@ output$plot_tssre_score <- renderPlot({
     )
 })
 
-output$plotCumulativePercentage <- renderPlot({
+cumulative_percentage_plot <- reactive({
     core <- inputDataReactive()
     nucleosome <- nucleosomeDataReactive()
     cumulativePercentage(
@@ -514,7 +574,7 @@ output$plotCumulativePercentage <- renderPlot({
     )
 })
 
-output$plot_tss_featureAlignedHeatmap <- renderPlot({
+tss_heatmap_plot <- reactive({
     nucleosome <- nucleosomeDataReactive()
     featureAlignedHeatmap(
         nucleosome$log2_signals,
@@ -524,7 +584,7 @@ output$plot_tss_featureAlignedHeatmap <- renderPlot({
     )
 })
 
-output$plot_signals <- renderPlot({
+nucleosome_signal_plot <- reactive({
     distribution <- nucleosomeDataReactive()$distribution
     matplot(
         distribution,
@@ -542,6 +602,38 @@ output$plot_signals <- renderPlot({
     abline(v = seq(0, 100, by = 10) + 1, lty = 2, col = "gray")
 })
 
+output$plot_pt_score <- renderPlot(pt_score_plot())
+output$plot_nfr_score <- renderPlot(nfr_score_plot())
+output$plot_tssre_score <- renderPlot(tss_enrichment_plot())
+output$plotCumulativePercentage <- renderPlot(cumulative_percentage_plot())
+output$plot_tss_featureAlignedHeatmap <- renderPlot(tss_heatmap_plot())
+output$plot_signals <- renderPlot(nucleosome_signal_plot())
+
+register_publication_downloads(
+    output, "download_pt_score", function() "atacseq-promoter-transcript-score",
+    pt_score_plot, width = 6.5, height = 5.5
+)
+register_publication_downloads(
+    output, "download_nfr_score", function() "atacseq-nucleosome-free-region-score",
+    nfr_score_plot, width = 6.5, height = 5.5
+)
+register_publication_downloads(
+    output, "download_tss_enrichment", function() "atacseq-tss-enrichment",
+    tss_enrichment_plot, width = 6.5, height = 5.5
+)
+register_publication_downloads(
+    output, "download_cumulative_tags", function() "atacseq-cumulative-tag-allocation",
+    cumulative_percentage_plot, width = 7, height = 5.5
+)
+register_publication_downloads(
+    output, "download_tss_heatmap", function() "atacseq-tss-aligned-heatmap",
+    tss_heatmap_plot, width = 10, height = 6
+)
+register_publication_downloads(
+    output, "download_nucleosome_signals", function() "atacseq-nucleosome-signals",
+    nucleosome_signal_plot, width = 10, height = 5.5
+)
+
 output$plot_Footprints <- renderImage({
     result <- footprintDataReactive()
     list(
@@ -551,7 +643,7 @@ output$plot_Footprints <- renderImage({
     )
 }, deleteFile = FALSE)
 
-output$plot_binding_sites_featureAlignedHeatmap <- renderPlot({
+binding_site_heatmap_plot <- reactive({
     signals <- footprintDataReactive()$signals
     featureAlignedHeatmap(
         signals$signal,
@@ -565,6 +657,12 @@ output$plot_binding_sites_featureAlignedHeatmap <- renderPlot({
     )
 })
 
+output$plot_binding_sites_featureAlignedHeatmap <- renderPlot(binding_site_heatmap_plot())
+register_publication_downloads(
+    output, "download_binding_heatmap", function() "atacseq-binding-site-heatmap",
+    binding_site_heatmap_plot, width = 8, height = 7
+)
+
 output$plot_vp <- renderImage({
     result <- footprintDataReactive()
     list(
@@ -574,9 +672,47 @@ output$plot_vp <- renderImage({
     )
 }, deleteFile = FALSE)
 
-output$plot_distanceDyad <- renderPlot({
-    distanceDyad(footprintDataReactive()$vplot, pch = 20, cex = 0.5)
+dyadEstimateReactive <- reactive({
+    with_null_device(
+        distanceDyad(
+            footprintDataReactive()$vplot,
+            pch = 20,
+            cex = 0.5
+        )
+    )
 })
+
+output$dyad_available <- reactive({
+    any(!is.na(dyadEstimateReactive()))
+})
+outputOptions(output, "dyad_available", suspendWhenHidden = FALSE)
+
+dyad_distance_plot <- reactive({
+    validate(need(
+        any(!is.na(dyadEstimateReactive())),
+        "No nucleosome dyad position is available."
+    ))
+    distanceDyad(
+        footprintDataReactive()$vplot,
+        pch = 20,
+        cex = 0.5
+    )
+})
+
+output$plot_distanceDyad <- renderPlot(dyad_distance_plot())
+register_publication_downloads(
+    output, "download_dyad_distance", function() "atacseq-nucleosome-dyad-distance",
+    dyad_distance_plot, width = 8, height = 5.5
+)
+
+register_publication_png(
+    output, "download_footprint", function() "atacseq-factor-footprint",
+    function() footprintDataReactive()$footprint_png
+)
+register_publication_png(
+    output, "download_vplot", function() "atacseq-fragment-vplot",
+    function() footprintDataReactive()$vplot_png
+)
 
 output$bamfilesTable <- renderDataTable(
     {

--- a/ATACseqQCShniy/src/server.R
+++ b/ATACseqQCShniy/src/server.R
@@ -1,32 +1,23 @@
 options(shiny.maxRequestSize = 30 * 1024^4)
 
 server <- function(input, output,session) {
-  # Function to check if a Bioconductor package is installed, and install it if not
   check_and_load_bioc_package <- function(pkg) {
-    
-    if (!require(pkg, character.only = TRUE)) {
-       withProgress(
-            message = paste0("Installing package ",pkg),
-            detail = "This may take a while...",
-            value = 0,
-            {
-                incProgress(0.4)
-                BiocManager::install(pkg, update = FALSE)
-                incProgress(0.4)
-                
-                    
-                    
-            }
-            
+    if (!requireNamespace(pkg, quietly = TRUE)) {
+        stop(
+            paste(
+                "Required genome package is not installed in this image:",
+                pkg
+            ),
+            call. = FALSE
         )
-
-        library(pkg, character.only = TRUE)
-
-      
-
     }
+    suppressPackageStartupMessages(
+        library(pkg, character.only = TRUE)
+    )
+    invisible(TRUE)
   }
 
+  source("plot-downloads.R", local = TRUE)
   source("server-inputdata.R", local = TRUE)
   source("server-heatmap.R", local = TRUE)
   source("server-librarycomplexity.R", local = TRUE)

--- a/ATACseqQCShniy/src/ui-tab-footprinting.R
+++ b/ATACseqQCShniy/src/ui-tab-footprinting.R
@@ -1,0 +1,150 @@
+tabItem(
+    tabName = "footprinting_tab",
+    fluidRow(
+        column(
+            12,
+            box(
+                title = "Transcription-factor footprinting",
+                solidHeader = TRUE,
+                status = "primary",
+                width = 12,
+                fluidRow(
+                    class = "analysis-plot-row",
+                    column(
+                        8,
+                        textInput(
+                            "motif_value",
+                            "Motif",
+                            value = "CTCF"
+                        )
+                    ),
+                    column(
+                        4,
+                        tags$div(
+                            class = "analysis-context",
+                            tags$strong("Core result: "),
+                            textOutput("footprint_context", inline = TRUE)
+                        )
+                    ),
+                    column(
+                        12,
+                        actionButton(
+                            "run_footprint_plots",
+                            "Run footprint analysis",
+                            class = "btn btn-primary",
+                            style = "width:100%;height:50px;"
+                        )
+                    )
+                )
+            ),
+            conditionalPanel(
+                condition = "output.footprint_task_done",
+                fluidRow(
+                    class = "analysis-plot-row",
+                    column(
+                        12,
+                        analysis_panel(
+                            "DNA-binding factor footprint",
+                            paste(
+                                "Forward- and reverse-strand cut-site probability",
+                                "around the selected motif."
+                            ),
+                            withSpinner(
+                                tags$div(
+                                    class = paste(
+                                        "analysis-image-frame",
+                                        "analysis-image-frame--wide"
+                                    ),
+                                    imageOutput(
+                                        "plot_Footprints",
+                                        width = "100%",
+                                        height = "100%"
+                                    )
+                                )
+                            ),
+                            publication_downloads("download_footprint", vector = FALSE)
+                        )
+                    )
+                ),
+                fluidRow(
+                    class = "analysis-plot-row",
+                    column(
+                        6,
+                        analysis_panel(
+                            "Binding-site heatmap",
+                            paste(
+                                "Tn5 cut signal aligned to motif binding sites",
+                                "and ordered by score."
+                            ),
+                            withSpinner(
+                                plotOutput(
+                                    "plot_binding_sites_featureAlignedHeatmap",
+                                    height = "520px"
+                                )
+                            ),
+                            publication_downloads("download_binding_heatmap")
+                        )
+                    ),
+                    column(
+                        6,
+                        analysis_panel(
+                            "Fragment midpoint versus length",
+                            paste(
+                                "Fragment length plotted against midpoint",
+                                "distance from the motif center."
+                            ),
+                            withSpinner(
+                                tags$div(
+                                    class = paste(
+                                        "analysis-image-frame",
+                                        "analysis-image-frame--standard"
+                                    ),
+                                    imageOutput(
+                                        "plot_vp",
+                                        width = "100%",
+                                        height = "100%"
+                                    )
+                                )
+                            ),
+                            publication_downloads("download_vplot", vector = FALSE)
+                        )
+                    )
+                ),
+                fluidRow(
+                    class = "analysis-plot-row",
+                    column(
+                        12,
+                        analysis_panel(
+                            "Distance of potential nucleosome dyad",
+                            "Estimated dyad position relative to the selected motif.",
+                            conditionalPanel(
+                                condition = "output.dyad_available",
+                                withSpinner(
+                                    plotOutput(
+                                        "plot_distanceDyad",
+                                        height = "420px"
+                                    )
+                                ),
+                                publication_downloads("download_dyad_distance")
+                            ),
+                            conditionalPanel(
+                                condition = "!output.dyad_available",
+                                tags$div(
+                                    class = "analysis-no-result",
+                                    icon("info-circle"),
+                                    tags$p(
+                                        paste(
+                                            "No nucleosome dyad position could be",
+                                            "estimated for this sample, chromosome,",
+                                            "and motif."
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+)

--- a/ATACseqQCShniy/src/ui-tab-fragmentsize.R
+++ b/ATACseqQCShniy/src/ui-tab-fragmentsize.R
@@ -4,12 +4,17 @@ tabItem(
     tabName = "fragmentsize_tab",
     fluidRow(
         column(
-            4,wellPanel(
+            3,wellPanel(
             selectInput("sample_fragmentsize", "Select Sample File", choices = NULL, selected = NULL))
         ),
         column(
-            7,
-            withSpinner(plotOutput("plot_fragmentsize"))
+            9,
+            analysis_panel(
+                "Fragment-size distribution",
+                "Distribution of aligned fragment lengths used to assess nucleosome periodicity.",
+                withSpinner(plotOutput("plot_fragmentsize", height = "560px")),
+                publication_downloads("download_fragment_size")
+            )
       
             # actionButton("run_deseq2", "Run DESeq2",
             #              class = "btn btn-success",

--- a/ATACseqQCShniy/src/ui-tab-heatmap.R
+++ b/ATACseqQCShniy/src/ui-tab-heatmap.R
@@ -7,7 +7,7 @@ tabItem(
         conditionalPanel("output.multiple_bamfiles",
 
         column(
-            4,wellPanel(
+            3, wellPanel(
             selectInput("sel_chromosome_heatmap_tab",
                             label = "Chromosome", # or Ensembl ID",
                             choices = NULL,
@@ -16,10 +16,12 @@ tabItem(
         ),
         
         column(
-            7,
-            wellPanel(
-                h5("Assessing similarity of replicates"),
-                withSpinner(plotOutput("plot_heatmap"))
+            9,
+            analysis_panel(
+                "Replicate correlation heatmap",
+                "Pairwise ATAC-seq signal similarity across uploaded BAM files for the selected chromosome.",
+                withSpinner(plotOutput("plot_heatmap", height = "620px")),
+                publication_downloads("download_replicate_heatmap")
             )
         )
         ),

--- a/ATACseqQCShniy/src/ui-tab-inputdata.R
+++ b/ATACseqQCShniy/src/ui-tab-inputdata.R
@@ -7,23 +7,22 @@ tabItem(
                 title = "Upload bam file", solidHeader = T, status = "primary", width = 12, collapsible = T, id = "uploadbox",
                 # h4("Upload Gene Counts"),
                 h4("(select .bam/.bai)"),
-                radioButtons("data_file_type", "Use example file or upload your own data",
+                radioButtons("data_file_type", "Input source",
                     c(
-                        "Upload bam File" = "upload_bam_file",
-                        "Example bam Data" = "example_bam_file",
-                        "Mount remote server" = "mount_remote_server"
+                        "Upload BAM files" = "upload_bam_file",
+                        "Example BAM data" = "example_bam_file",
+                        "Use HPC scratch directory" = "hpc_scratch_directory"
                     ),
                     selected = "upload_bam_file"
                 ),
                 conditionalPanel(
-                    condition = "input.data_file_type=='mount_remote_server'",
-                    p("Upload ssh private key "),
-                    fileInput("id_rsa", ""),
-                    textInput("username", "User name", value=''),
-                    textInput("hostname", "Server name", value=''),
-                    textInput("mountpoint", "Directory to mount on remote server", value=''),
-                    actionButton("connect_remote_server", "Connect")
-
+                    condition = "input.data_file_type=='hpc_scratch_directory'",
+                    textInput(
+                        "scratch_directory",
+                        "Directory containing BAM and BAI files",
+                        value = Sys.getenv("NASQAR_DATA_ROOT", unset = "/scratch/nr83")
+                    ),
+                    actionButton("load_scratch_directory", "Load directory")
                 ),
                 conditionalPanel(
                     condition = "input.data_file_type=='upload_bam_file'",

--- a/ATACseqQCShniy/src/ui-tab-librarycomplexity.R
+++ b/ATACseqQCShniy/src/ui-tab-librarycomplexity.R
@@ -4,15 +4,16 @@ tabItem(
     tabName = "librarycomplexity_tab",
     fluidRow(
         column(
-            4,wellPanel(
-            selectInput("sample_librarycomplexity", "Salect Sample File", choices = NULL, selected = NULL))
+            3,wellPanel(
+            selectInput("sample_librarycomplexity", "Select Sample File", choices = NULL, selected = NULL))
         ),
         column(
-            7,
-            wellPanel(
-            h5("Assessing sequencing depth and library complexity"),
-            withSpinner(plotOutput("plot_libcomplexity")),
-            h5("BAM files without removing duplicates are expected for estimating library complexity!")
+            9,
+            analysis_panel(
+            "Library complexity",
+            "Estimated sequencing-library complexity. Use a BAM file that retains duplicate reads.",
+            withSpinner(plotOutput("plot_libcomplexity", height = "560px")),
+            publication_downloads("download_library_complexity")
             )
       
             # actionButton("run_deseq2", "Run DESeq2",

--- a/ATACseqQCShniy/src/ui-tab-nucleosomepositioning.R
+++ b/ATACseqQCShniy/src/ui-tab-nucleosomepositioning.R
@@ -3,266 +3,182 @@ tabItem(
     fluidRow(
         column(
             12,
-            column(
-                12,
-                box(
-                    title = "Upload bam file", solidHeader = T, status = "primary", width = 12, collapsible = T, id = "selectSample1",
-                    fluidRow(
-                        column(
-                            6,
-                            selectInput("sel_sample_for_npositioning", "Select sample", choices = NULL, selected = NULL)
-                        ),
-                        column(
-                            1,
-                            selectInput("sel_chromosome",
-                                label = "Chromosome", # or Ensembl ID",
-                                choices = NULL,
-                            )
-                        ),
-                        # Records
-                        # column(
-                        #     3,
-                        #     numericInput("record_count_value", span(
-                        #         "Alignments to process",
-                        #         span(
-                        #             class = "TOOLTIP1",
-                        #             `data-toggle` = "tooltip", `data-placement` = "right",
-                        #             title = "A tooltip",
-                        #             icon("question-circle", "fa-solid")
-                        #         )
-                        #     ), value = 100, min = 0),
-                        #     htmltags$script(
-                        #                                 "
-                        #         $('#record_count_value').on('shiny:updateinput', function(e){
-                        #             setTimeout(function(){$('#record_count_value-label').html($('#record_count_value-label').text())}, 0.1);
-                        #         });
-                        #         "
-                        #     )
-                        # ),
-                        column(
-                            2,
-                            textInput("motif_value", "Motif of interest", value = "CTCF")
-                        ),
-                        span(
-                            "",
-                            span(
-                                class = "TOOLTIP1",
-                                `data-toggle` = "tooltip", `data-placement` = "right",
-                                title = "A tooltip",
-                                icon("question-circle", "fa-solid")
-                            )
-                        ),
-                        # # Integer type tags
-                        # column(
-                        #     6,
-                        #     selectizeInput("sel_tag_integer_type",
-                        #         span(
-                        #             "SAM integer type flags",
-                        #             #
-                        #             tags$a(
-                        #                 span(
-                        #                     class = "TOOLTIP1",
-                        #                     `data-toggle` = "tooltip", `data-placement` = "right",
-                        #                     title = "For more information about sam flags click herel",
-                        #                     icon("question-circle", "fa-solid")
-                        #                 ),
-                        #                 target = "_blank",
-                        #                 href = "https://samtools.github.io/hts-specs/SAMtags.pdf"
-                        #             )
-                        #         ),
-                        #         # or Ensembl ID",
-                        #         choices = NULL,
-                        #         multiple = TRUE,
-                        #         options = list(
-                        #             placeholder =
-                        #                 "Start typing to search for tags" # or ID',
-                        #         )
-                        #     )
-                        # ),
-                        # # Character type tags
-                        # column(
-                        #     6,
-                        #     selectizeInput("sel_tag_char_type",
-                        #         span(
-                        #             "SAM charter type flags",
-                        #             #
-                        #             tags$a(
-                        #                 span(
-                        #                     class = "TOOLTIP1",
-                        #                     `data-toggle` = "tooltip", `data-placement` = "right",
-                        #                     title = "For more information about sam flags click herel",
-                        #                     icon("question-circle", "fa-solid")
-                        #                 ),
-                        #                 target = "_blank",
-                        #                 href = "https://samtools.github.io/hts-specs/SAMtags.pdf"
-                        #             )
-                        #         ),
-                        #         choices = NULL,
-                        #         multiple = TRUE,
-                        #         options = list(
-                        #             placeholder =
-                        #                 "Start typing to search for a gene name/id" # or ID',
-                        #         )
-                        #     )
-                        # ),
-                        column(
-                            12,
-                            actionButton("run_qc", "Run QC",
-                                class = "btn btn-success",
-                                style = "width:100%;height:60px;"
-                            )
+            box(
+                title = "Nucleosome positioning",
+                solidHeader = TRUE,
+                status = "primary",
+                width = 12,
+                collapsible = TRUE,
+                id = "selectSample1",
+                fluidRow(
+                    column(
+                        6,
+                        selectInput(
+                            "sel_sample_for_npositioning",
+                            "Sample",
+                            choices = NULL,
+                            selected = NULL
+                        )
+                    ),
+                    column(
+                        2,
+                        selectInput(
+                            "sel_chromosome",
+                            "Chromosome",
+                            choices = NULL,
+                            selected = NULL
+                        )
+                    ),
+                    column(
+                        4,
+                        textInput(
+                            "motif_value",
+                            "Motif for optional footprinting",
+                            value = "CTCF"
+                        )
+                    ),
+                    column(
+                        12,
+                        actionButton(
+                            "run_qc",
+                            "Run core QC",
+                            class = "btn btn-success",
+                            style = "width:100%;height:54px;"
                         )
                     )
                 )
             ),
-            column(
-                12,
-                textOutput("empty_txt_output")
+            textOutput("empty_txt_output"),
+            conditionalPanel(
+                condition = "output.task_done",
+                fluidRow(
+                    column(
+                        6,
+                        wellPanel(
+                            h3("Promoter/transcript body score"),
+                            withSpinner(plotOutput("plot_pt_score"))
+                        )
+                    ),
+                    column(
+                        6,
+                        wellPanel(
+                            h3("Nucleosome-free region score"),
+                            withSpinner(plotOutput("plot_nfr_score"))
+                        )
+                    ),
+                    column(
+                        6,
+                        wellPanel(
+                            h3("TSS enrichment score"),
+                            withSpinner(plotOutput("plot_tssre_score"))
+                        )
+                    )
+                ),
+                fluidRow(
+                    column(
+                        6,
+                        actionButton(
+                            "run_nucleosome_plots",
+                            "Run nucleosome plots",
+                            class = "btn btn-primary",
+                            style = "width:100%;height:50px;"
+                        )
+                    ),
+                    column(
+                        6,
+                        actionButton(
+                            "run_footprint_plots",
+                            "Run footprint plots",
+                            class = "btn btn-primary",
+                            style = "width:100%;height:50px;"
+                        )
+                    )
+                )
             ),
             conditionalPanel(
-                "output.task_done",
-                column(
-                    12,
+                condition = "output.nucleosome_task_done",
+                fluidRow(
                     column(
                         6,
                         wellPanel(
-                            h3("Promoter/Transcript body (PT) score"),
-                            withSpinner(plotOutput("plot_pt_score")),
-                            h5("The Promoter/Transcript Body (PT) score is a metric used to assess signal is enriched 
-                            in promoter regions compared to the transcript body regions. It helps in evaluating 
-                            the presence of regulatory elements and potential gene expression regulation.
-                            PT score is calculated as the coverage of promoter divided by the coverage of its transcript body")
+                            h3("Cumulative tag allocation"),
+                            withSpinner(plotOutput("plotCumulativePercentage"))
                         )
                     ),
                     column(
                         6,
                         wellPanel(
-                            h3("Nucleosome Free Regions (NFR) score"),
-                            withSpinner(plotOutput("plot_nfr_score")),
-                            h5("NFR score is a ratio between cut signal adjacent to TSS and that flanking the corresponding TSS.
-                            Each TSS window of 400 bp is first divided into 3 sub-regions: the most upstream 150 bp (n1), the most
-                            downstream of 150 bp (n2), and the middle 100 bp (nf). Then the number of fragments with 5\' ends overlapping
-                            each region are calculated for each TSS."),
-                            h5("The NFR score for each TSS is calculated as NFR-score = log2(nf) - log2((n1+n2)/2)"),
-                            h5("A plot can be generated with the NFR scores as Y-axis and the average signals of 400 bp window as X-axis, very like a MA plot
-                            for gene expression data.")
+                            h3("TSS-aligned heatmap"),
+                            withSpinner(plotOutput("plot_tss_featureAlignedHeatmap"))
                         )
                     ),
                     column(
-                        6,
+                        12,
                         wellPanel(
-                            h3("TSSR score"),
-                            withSpinner(plotOutput("plot_tssre_score")),
-                            h5("TSS enrichment score is a raio between aggregate distribution of reads centered on TSSs and that flanking the corresponding TSSs.
-                            TSS score = the depth of TSS (each 100bp window within 1000 bp each side) / the depth of end flanks (100bp each end).
-                            TSSE score = max(mean(TSS score in each window))"),
-                            h5("TSS enrichment score is calculated according to the definition given in the",a("link", href = "https://www.encodeproject.org/data-standards/terms/#enrichment")),
-                            h5("Transcription start site (TSS) enrichment values are dependent on the reference files used;
-                            cutoff values for high quality can be reffered ", a("here",href = "https://www.encodeproject.org/atac-seq/") )
-
+                            h3("Nucleosome-free and nucleosome-bound distributions"),
+                            withSpinner(plotOutput("plot_signals"))
                         )
-                    )
-                ),
-                column(12,
-                    wellPanel(
-                        h3("Signal distribution around transcriptional start sites (TSSs)"),
-                        h5("By averaging the signal across all active TSSs, we should observe that nucleosome-free
-                        fragments are enriched at the TSSs, whereas the nucleosome-bound fragments should be enriched
-                        both upstream and downstream of the active TSSs and display characteristic phasing of upstream
-                        and downstream nucleosomes. Because ATAC-seq reads are concentrated at regions of open chromatin, 
-                        users should see a strong nucleosome signal at the +1 nucleosome,
-                        but the signal decreases at the +2, +3 and +4 nucleosomes.")
-                    )
-                ),
-                column(
-                    6,
-                    wellPanel(
-                        h3("Cumulative percentage of tag allocation in nucleosome-free and mononucleosome bam files."),
-                        withSpinner(plotOutput("plotCumulativePercentage"))
-                    )
-                ),
-                column(
-                    6,
-                    wellPanel(
-                        h3("Heatmap: Distributions of reads from different bins around TSSs"),
-                        withSpinner(plotOutput("plot_tss_featureAlignedHeatmap"))
-                        
-                    )
-                ),
-
-                # column(
-                #     7,
-                #     wellPanel(
-                #         h3('plot_featureAlignedHeatmap'),
-                #         withSpinner(plotOutput("plot_featureAlignedHeatmap")))
-                # ),
-                column(
-                    7,
-                    wellPanel(
-                        h3("Distribution of nucleosome-free and nucleosome-bound regions"),
-                        withSpinner(plotOutput("plot_signals")),
-                        h5("Density plot showing distributions of reads from different bins around TSSs.
-                    Black line, signal generated from nucleosome-free bin; red line, singal
-                    from mononucleosome bin.")
-                    )
-                ),
-
-                column(12,
-                    wellPanel(
-                        h3("Signal distribution around binding sites")
-                       
-                    )
-                ),
-                column(
-                    6,
-                    wellPanel(
-                        h3("Footprints of DNA-binding factors."),
-                        # withSpinner(uiOutput("plots"))
-                        # ,
-                        withSpinner(plotOutput("plot_Footprints"))
-                    )
-                ),
-                column(
-                    6,
-                    wellPanel(
-                        h3("Heatmap: Distributions of reads from different bins around binding sites"),
-                        withSpinner(plotOutput("plot_binding_sites_featureAlignedHeatmap"))
-                        
-                    )
-                ),
-                column(
-                    7,
-                    wellPanel(
-                        h3("Aggregate ATAC-seq Fragment Midpoint vs. Length for a given motif generated over binding sites within the genome"),
-                        withSpinner(plotOutput("plot_vp"))
-                    )
-                ),
-                column(
-                    7,
-                    wellPanel(
-                        h3("Distance of potential nucleosome dyad and the linear model for V"),
-                        withSpinner(plotOutput("plot_distanceDyad"))
-                    )
-                ),
-                  column(
+                    ),
+                    column(
                         10,
-                    tags$div(
-                        class = "BoxArea2",
-                        withSpinner(dataTableOutput("bamfilesTable"))
-                    ),
-                    downloadButton(
-                        outputId = "download_bamfiles_btn",
-                        label = "Download",
-                        icon = icon("file-download")
+                        tags$div(
+                            class = "BoxArea2",
+                            withSpinner(dataTableOutput("bamfilesTable"))
+                        ),
+                        downloadButton(
+                            outputId = "download_bamfiles_btn",
+                            label = "Download selected BAM files",
+                            icon = icon("file-download")
+                        )
                     )
-                  )
-
-
-                # actionButton("run_deseq2", "Run DESeq2",
-                #              class = "btn btn-success",
-                #              style = "width:100%;height:60px;"
-                # ),
-                # plotOutput("plot")
+                )
+            ),
+            conditionalPanel(
+                condition = "output.footprint_task_done",
+                fluidRow(
+                    column(
+                        6,
+                        wellPanel(
+                            h3("DNA-binding factor footprint"),
+                            withSpinner(
+                                imageOutput(
+                                    "plot_Footprints",
+                                    width = "100%",
+                                    height = "520px"
+                                )
+                            )
+                        )
+                    ),
+                    column(
+                        6,
+                        wellPanel(
+                            h3("Binding-site heatmap"),
+                            withSpinner(
+                                plotOutput("plot_binding_sites_featureAlignedHeatmap")
+                            )
+                        )
+                    ),
+                    column(
+                        7,
+                        wellPanel(
+                            h3("Fragment midpoint versus length"),
+                            withSpinner(
+                                imageOutput(
+                                    "plot_vp",
+                                    width = "100%",
+                                    height = "520px"
+                                )
+                            )
+                        )
+                    ),
+                    column(
+                        7,
+                        wellPanel(
+                            h3("Distance of potential nucleosome dyad"),
+                            withSpinner(plotOutput("plot_distanceDyad"))
+                        )
+                    )
+                )
             )
         )
     )

--- a/ATACseqQCShniy/src/ui-tab-nucleosomepositioning.R
+++ b/ATACseqQCShniy/src/ui-tab-nucleosomepositioning.R
@@ -4,7 +4,7 @@ tabItem(
         column(
             12,
             box(
-                title = "Nucleosome positioning",
+                title = "Core ATAC-seq QC",
                 solidHeader = TRUE,
                 status = "primary",
                 width = 12,
@@ -30,14 +30,6 @@ tabItem(
                         )
                     ),
                     column(
-                        4,
-                        textInput(
-                            "motif_value",
-                            "Motif for optional footprinting",
-                            value = "CTCF"
-                        )
-                    ),
-                    column(
                         12,
                         actionButton(
                             "run_qc",
@@ -52,130 +44,32 @@ tabItem(
             conditionalPanel(
                 condition = "output.task_done",
                 fluidRow(
+                    class = "analysis-plot-row",
                     column(
-                        6,
-                        wellPanel(
-                            h3("Promoter/transcript body score"),
-                            withSpinner(plotOutput("plot_pt_score"))
+                        4,
+                        analysis_panel(
+                            "Promoter/transcript body score",
+                            "Promoter enrichment relative to transcript-body coverage.",
+                            withSpinner(plotOutput("plot_pt_score", height = "400px")),
+                            publication_downloads("download_pt_score")
                         )
                     ),
                     column(
-                        6,
-                        wellPanel(
-                            h3("Nucleosome-free region score"),
-                            withSpinner(plotOutput("plot_nfr_score"))
+                        4,
+                        analysis_panel(
+                            "Nucleosome-free region score",
+                            "Accessibility around transcription start sites.",
+                            withSpinner(plotOutput("plot_nfr_score", height = "400px")),
+                            publication_downloads("download_nfr_score")
                         )
                     ),
                     column(
-                        6,
-                        wellPanel(
-                            h3("TSS enrichment score"),
-                            withSpinner(plotOutput("plot_tssre_score"))
-                        )
-                    )
-                ),
-                fluidRow(
-                    column(
-                        6,
-                        actionButton(
-                            "run_nucleosome_plots",
-                            "Run nucleosome plots",
-                            class = "btn btn-primary",
-                            style = "width:100%;height:50px;"
-                        )
-                    ),
-                    column(
-                        6,
-                        actionButton(
-                            "run_footprint_plots",
-                            "Run footprint plots",
-                            class = "btn btn-primary",
-                            style = "width:100%;height:50px;"
-                        )
-                    )
-                )
-            ),
-            conditionalPanel(
-                condition = "output.nucleosome_task_done",
-                fluidRow(
-                    column(
-                        6,
-                        wellPanel(
-                            h3("Cumulative tag allocation"),
-                            withSpinner(plotOutput("plotCumulativePercentage"))
-                        )
-                    ),
-                    column(
-                        6,
-                        wellPanel(
-                            h3("TSS-aligned heatmap"),
-                            withSpinner(plotOutput("plot_tss_featureAlignedHeatmap"))
-                        )
-                    ),
-                    column(
-                        12,
-                        wellPanel(
-                            h3("Nucleosome-free and nucleosome-bound distributions"),
-                            withSpinner(plotOutput("plot_signals"))
-                        )
-                    ),
-                    column(
-                        10,
-                        tags$div(
-                            class = "BoxArea2",
-                            withSpinner(dataTableOutput("bamfilesTable"))
-                        ),
-                        downloadButton(
-                            outputId = "download_bamfiles_btn",
-                            label = "Download selected BAM files",
-                            icon = icon("file-download")
-                        )
-                    )
-                )
-            ),
-            conditionalPanel(
-                condition = "output.footprint_task_done",
-                fluidRow(
-                    column(
-                        6,
-                        wellPanel(
-                            h3("DNA-binding factor footprint"),
-                            withSpinner(
-                                imageOutput(
-                                    "plot_Footprints",
-                                    width = "100%",
-                                    height = "520px"
-                                )
-                            )
-                        )
-                    ),
-                    column(
-                        6,
-                        wellPanel(
-                            h3("Binding-site heatmap"),
-                            withSpinner(
-                                plotOutput("plot_binding_sites_featureAlignedHeatmap")
-                            )
-                        )
-                    ),
-                    column(
-                        7,
-                        wellPanel(
-                            h3("Fragment midpoint versus length"),
-                            withSpinner(
-                                imageOutput(
-                                    "plot_vp",
-                                    width = "100%",
-                                    height = "520px"
-                                )
-                            )
-                        )
-                    ),
-                    column(
-                        7,
-                        wellPanel(
-                            h3("Distance of potential nucleosome dyad"),
-                            withSpinner(plotOutput("plot_distanceDyad"))
+                        4,
+                        analysis_panel(
+                            "TSS enrichment score",
+                            "Aggregate cut-site enrichment centered on transcription start sites.",
+                            withSpinner(plotOutput("plot_tssre_score", height = "400px")),
+                            publication_downloads("download_tss_enrichment")
                         )
                     )
                 )

--- a/ATACseqQCShniy/src/ui-tab-nucleosomeprofiles.R
+++ b/ATACseqQCShniy/src/ui-tab-nucleosomeprofiles.R
@@ -1,0 +1,86 @@
+tabItem(
+    tabName = "nucleosomeprofiles_tab",
+    fluidRow(
+        column(
+            12,
+            box(
+                title = "Nucleosome profiles",
+                solidHeader = TRUE,
+                status = "primary",
+                width = 12,
+                tags$div(
+                    class = "analysis-context",
+                    tags$strong("Core result: "),
+                    textOutput("nucleosome_context", inline = TRUE)
+                ),
+                actionButton(
+                    "run_nucleosome_plots",
+                    "Run nucleosome analysis",
+                    class = "btn btn-primary",
+                    style = "width:100%;height:50px;"
+                )
+            ),
+            conditionalPanel(
+                condition = "output.nucleosome_task_done",
+                fluidRow(
+                    class = "analysis-plot-row",
+                    column(
+                        5,
+                        analysis_panel(
+                            "Cumulative tag allocation",
+                            "Cumulative fraction of nucleosome-free and mononucleosome fragments.",
+                            withSpinner(
+                                plotOutput(
+                                    "plotCumulativePercentage",
+                                    height = "420px"
+                                )
+                            ),
+                            publication_downloads("download_cumulative_tags")
+                        )
+                    ),
+                    column(
+                        7,
+                        analysis_panel(
+                            "TSS-aligned heatmap",
+                            "Fragment-class signal aligned across transcription start sites.",
+                            withSpinner(
+                                plotOutput(
+                                    "plot_tss_featureAlignedHeatmap",
+                                    height = "420px"
+                                )
+                            ),
+                            publication_downloads("download_tss_heatmap")
+                        )
+                    )
+                ),
+                fluidRow(
+                    class = "analysis-plot-row",
+                    column(
+                        12,
+                        analysis_panel(
+                            "Nucleosome-free and nucleosome-bound distributions",
+                            "Normalized fragment-class coverage across the TSS window.",
+                            withSpinner(plotOutput("plot_signals", height = "420px")),
+                            publication_downloads("download_nucleosome_signals")
+                        )
+                    )
+                ),
+                fluidRow(
+                    column(
+                        12,
+                        analysis_panel(
+                            "Generated fragment-class BAM files",
+                            "Derived alignment files are available for downstream analysis.",
+                            withSpinner(dataTableOutput("bamfilesTable"))
+                        ),
+                        downloadButton(
+                            outputId = "download_bamfiles_btn",
+                            label = "Download selected BAM files",
+                            icon = icon("file-download")
+                        )
+                    )
+                )
+            )
+        )
+    )
+)

--- a/ATACseqQCShniy/src/ui.R
+++ b/ATACseqQCShniy/src/ui.R
@@ -10,6 +10,36 @@ require(DT)
 
 
 htmltags<- tags
+
+analysis_panel <- function(title, caption, ..., class = NULL) {
+    tags$section(
+        class = paste("analysis-panel", class),
+        tags$header(
+            class = "analysis-panel__header",
+            tags$h3(title)
+        ),
+        tags$div(class = "analysis-panel__body", ...),
+        tags$footer(class = "analysis-panel__caption", caption)
+    )
+}
+
+publication_downloads <- function(id, vector = TRUE) {
+    controls <- list(
+        tags$span(class = "publication-downloads__label", "Download figure"),
+        downloadButton(paste0(id, "_png"), "PNG (300 DPI)", class = "btn btn-default btn-sm")
+    )
+    if (vector) {
+        controls <- c(
+            controls,
+            list(
+                downloadButton(paste0(id, "_pdf"), "PDF", class = "btn btn-default btn-sm"),
+                downloadButton(paste0(id, "_svg"), "SVG", class = "btn btn-default btn-sm")
+            )
+        )
+    }
+    tags$div(class = "publication-downloads", controls)
+}
+
 ui <- dashboardPage(
     dashboardHeader(title = "ATACseqQC"),
     dashboardSidebar(
@@ -17,9 +47,23 @@ ui <- dashboardPage(
             id = "tabs",
             menuItem("Input Data", tabName = "input_tab", icon = icon("upload")),
             menuItem("Heatmap", tabName = "heatmap_tab"),
-            menuItem("Libraray Complexity", tabName = "librarycomplexity_tab"),
+            menuItem("Library Complexity", tabName = "librarycomplexity_tab"),
             menuItem("Fragment size", tabName = "fragmentsize_tab"),
-            menuItem("Nucleosome Positioning", tabName = "nucleosomepositioning_tab")
+            menuItem(
+                "Core QC",
+                tabName = "nucleosomepositioning_tab",
+                icon = icon("check-circle")
+            ),
+            menuItem(
+                "Nucleosome Profiles",
+                tabName = "nucleosomeprofiles_tab",
+                icon = icon("area-chart")
+            ),
+            menuItem(
+                "TF Footprinting",
+                tabName = "footprinting_tab",
+                icon = icon("bullseye")
+            )
         )
     ),
     dashboardBody(
@@ -29,7 +73,11 @@ ui <- dashboardPage(
         htmltags$head(
             htmltags$style(HTML(" .shiny-output-error-validation {color: darkred; } ")),
             htmltags$style(".mybuttonclass{background-color:#CD0000;} .mybuttonclass{color: #fff;} .mybuttonclass{border-color: #9E0000;}"),
-            htmltags$link(rel = "stylesheet", type = "text/css", href = "custom.css")
+            htmltags$link(
+                rel = "stylesheet",
+                type = "text/css",
+                href = "custom.css?v=20260729-scientific-panels"
+            )
         
         ),
         tabItems(
@@ -37,7 +85,9 @@ ui <- dashboardPage(
             source("ui-tab-heatmap.R", local = TRUE)$value,
             source("ui-tab-librarycomplexity.R", local = TRUE)$value,
             source("ui-tab-fragmentsize.R", local = TRUE)$value,
-            source("ui-tab-nucleosomepositioning.R", local = TRUE)$value
+            source("ui-tab-nucleosomepositioning.R", local = TRUE)$value,
+            source("ui-tab-nucleosomeprofiles.R", local = TRUE)$value,
+            source("ui-tab-footprinting.R", local = TRUE)$value
             
         )
     )

--- a/ATACseqQCShniy/src/www/custom.css
+++ b/ATACseqQCShniy/src/www/custom.css
@@ -205,6 +205,165 @@ body {
     font-size: 16px;
 }
 
+.analysis-context {
+    min-height: 54px;
+    padding: 10px 0;
+}
+
+.analysis-image-frame {
+    width: 100%;
+    overflow: hidden;
+    background: #fff;
+}
+
+.analysis-image-frame--wide {
+    height: 620px;
+}
+
+.analysis-image-frame--standard {
+    height: 520px;
+}
+
+.analysis-image-frame .shiny-image-output {
+    width: 100% !important;
+    height: 100% !important;
+    overflow: hidden;
+}
+
+.analysis-image-frame .shiny-image-output img {
+    display: block;
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100%;
+    object-fit: contain;
+}
+
+.analysis-image-frame img {
+    display: block;
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100% !important;
+    max-height: 100% !important;
+    object-fit: contain;
+}
+
+.analysis-panel {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin: 0 0 24px;
+    overflow: hidden;
+    border: 1px solid #c7d0d9;
+    border-radius: 4px;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(20, 35, 50, 0.08);
+}
+
+.analysis-panel__header {
+    min-height: 60px;
+    padding: 16px 20px;
+    border-bottom: 1px solid #d9e0e6;
+    background: #f5f7f9;
+}
+
+.analysis-panel__header h3 {
+    margin: 0;
+    color: #202830;
+    font-size: 22px;
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+.analysis-panel__body {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 18px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.analysis-panel__body .shiny-spinner-output-container,
+.analysis-panel__body .load-container {
+    width: 100%;
+    max-width: 100%;
+}
+
+.analysis-panel__caption {
+    min-height: 52px;
+    padding: 13px 20px;
+    border-top: 1px solid #e1e6ea;
+    color: #53616d;
+    background: #fafbfc;
+    font-size: 15px;
+    line-height: 1.45;
+}
+
+.publication-downloads {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px 0 0;
+    margin-top: 12px;
+    border-top: 1px solid #e1e6ea;
+}
+
+.publication-downloads__label {
+    color: #4f5b66;
+    font-weight: 600;
+    margin-right: 4px;
+}
+
+.analysis-no-result {
+    display: flex;
+    min-height: 110px;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 20px;
+    color: #7b2d26;
+    border: 1px solid #edcbc6;
+    background: #fff7f6;
+    text-align: center;
+}
+
+.analysis-no-result .fa {
+    font-size: 22px;
+}
+
+.analysis-no-result p {
+    max-width: 760px;
+    margin: 0;
+}
+
+.analysis-plot-row {
+    display: flex;
+    flex-wrap: wrap;
+    clear: both;
+}
+
+.analysis-plot-row > [class*="col-"] {
+    display: flex;
+}
+
+.analysis-plot-row .shiny-plot-output,
+.analysis-plot-row .shiny-image-output,
+.analysis-plot-row img {
+    max-width: 100% !important;
+}
+
+@media (max-width: 767px) {
+    .analysis-plot-row > [class*="col-"] {
+        display: block;
+        width: 100%;
+    }
+
+    .analysis-image-frame--wide,
+    .analysis-image-frame--standard {
+        height: 360px;
+    }
+}
+
 .modal-dialog {
     width: 50%;
 }

--- a/ClusterProfShinyGSEA/environment.yaml
+++ b/ClusterProfShinyGSEA/environment.yaml
@@ -21,3 +21,6 @@ dependencies:
   - r-sodium
   - bioconductor-clusterprofiler
   - bioconductor-pathview
+  - bioconductor-org.hs.eg.db
+  - bioconductor-org.mm.eg.db
+  - bioconductor-org.dm.eg.db

--- a/ClusterProfShinyGSEA/src/exchange-helpers.R
+++ b/ClusterProfShinyGSEA/src/exchange-helpers.R
@@ -1,0 +1,69 @@
+nasqar_exchange_dir <- function(create = FALSE) {
+    configured <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
+    path <- if (nzchar(configured)) {
+        configured
+    } else {
+        file.path(dirname(tempdir(check = TRUE)), "nasqar_exchange")
+    }
+    if (create) {
+        dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    }
+    normalizePath(path, mustWork = create)
+}
+
+validate_exchange_path <- function(path, extension = ".csv") {
+    if (!is.character(path) || length(path) != 1L || !nzchar(path)) {
+        stop("Invalid NASQAR2 exchange path.", call. = FALSE)
+    }
+
+    root <- nasqar_exchange_dir(create = TRUE)
+    resolved <- normalizePath(path, mustWork = TRUE)
+    prefix <- paste0(root, .Platform$file.sep)
+    uuid_file <- paste0(
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-",
+        "[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        gsub(".", "[.]", extension, fixed = TRUE),
+        "$"
+    )
+    if (!startsWith(resolved, prefix) ||
+        !grepl(uuid_file, basename(resolved))) {
+        stop("Exchange file is outside the NASQAR2 exchange directory.",
+             call. = FALSE)
+    }
+
+    info <- file.info(resolved)
+    if (is.na(info$isdir) || info$isdir || info$size > 600 * 1024^2) {
+        stop("Exchange file is invalid or too large.", call. = FALSE)
+    }
+    resolved
+}
+
+installed_organism_choices <- function() {
+    choices <- c(
+        "Human" = "org.Hs.eg.db",
+        "Mouse" = "org.Mm.eg.db",
+        "Rat" = "org.Rn.eg.db",
+        "Yeast" = "org.Sc.sgd.db",
+        "Fly" = "org.Dm.eg.db",
+        "Arabidopsis" = "org.At.tair.db",
+        "Zebrafish" = "org.Dr.eg.db",
+        "Bovine" = "org.Bt.eg.db",
+        "Worm" = "org.Ce.eg.db",
+        "Chicken" = "org.Gg.eg.db",
+        "Canine" = "org.Cf.eg.db",
+        "Pig" = "org.Ss.eg.db",
+        "Rhesus" = "org.Mmu.eg.db",
+        "E. coli K12" = "org.EcK12.eg.db",
+        "Xenopus" = "org.Xl.eg.db",
+        "Chimpanzee" = "org.Pt.eg.db",
+        "Anopheles" = "org.Ag.eg.db",
+        "Malaria parasite" = "org.Pf.plasmo.db",
+        "E. coli Sakai" = "org.EcSakai.eg.db"
+    )
+    choices[vapply(
+        unname(choices),
+        requireNamespace,
+        quietly = TRUE,
+        FUN.VALUE = logical(1)
+    )]
+}

--- a/ClusterProfShinyGSEA/src/plot-helpers.R
+++ b/ClusterProfShinyGSEA/src/plot-helpers.R
@@ -18,18 +18,40 @@ make_downloader <- function(output, plot_id, plot_fn, width = 10, height = 7) {
                 content  = function(file) {
                     switch(f,
                         png = grDevices::png(file,
-                                width  = round(width  * 150),
-                                height = round(height * 150),
-                                res    = 150),
-                        pdf = grDevices::pdf(file, width = width, height = height),
+                                width  = round(width  * 300),
+                                height = round(height * 300),
+                                res    = 300),
+                        pdf = grDevices::pdf(
+                                file, width = width, height = height,
+                                useDingbats = FALSE),
                         svg = grDevices::svg(file, width = width, height = height)
                     )
-                    tryCatch(print(plot_fn()), error = function(e) NULL)
-                    grDevices::dev.off()
+                    on.exit(grDevices::dev.off(), add = TRUE)
+                    print(plot_fn())
                 }
             )
         })
     }
+}
+
+publication_plotly_config <- function(
+    plot,
+    filename,
+    width = 2400,
+    height = 1600
+) {
+    plotly::config(
+        plot,
+        responsive = TRUE,
+        displaylogo = FALSE,
+        toImageButtonOptions = list(
+            format = "png",
+            filename = filename,
+            width = width,
+            height = height,
+            scale = 2
+        )
+    )
 }
 
 # ── KEGG KO ID converter ──────────────────────────────────────────────────────
@@ -138,7 +160,7 @@ build_ko_map <- function(entrez_ids, org) {
 plot_dl_buttons <- function(plot_id) {
     tags$div(
         style = "margin-top:6px;",
-        downloadButton(paste0("dl_", plot_id, "_png"), "PNG",
+        downloadButton(paste0("dl_", plot_id, "_png"), "PNG (300 DPI)",
                        class = "btn btn-xs btn-default"),
         tags$span("\u00a0"),
         downloadButton(paste0("dl_", plot_id, "_pdf"), "PDF",

--- a/ClusterProfShinyGSEA/src/server-gseGo.R
+++ b/ClusterProfShinyGSEA/src/server-gseGo.R
@@ -537,7 +537,7 @@ output$genesInKeggPathway <- plotly::renderPlotly({
                     shareX = TRUE, titleY = TRUE) %>%
         plotly::layout(plot_bgcolor = "#ffffff", paper_bgcolor = "#ffffff",
                        margin = list(l = 220), autosize = TRUE) %>%
-        plotly::config(responsive = TRUE) %>%
+        publication_plotly_config("gsea-kegg-gene-membership") %>%
         htmlwidgets::onRender("function(el) { setTimeout(function() { Plotly.Plots.resize(el); }, 300); }")
 })
 

--- a/ClusterProfShinyGSEA/src/server-inputData.R
+++ b/ClusterProfShinyGSEA/src/server-inputData.R
@@ -9,6 +9,7 @@ decryptUrlParam <- function(cipher) {
     unserialize(orig)
 }
 
+organismsDbChoices <- installed_organism_choices()
 
 observe({
     shinyjs::hide(selector = "a[data-value=\"gseGoTab\"]")
@@ -34,8 +35,10 @@ inputDataReactive <- reactive({
     )
 
     if (!is.null(query[["countsdata"]])) {
-        inFile <- decryptUrlParam(query[["countsdata"]])
-        data <- read.csv(inFile)
+        inFile <- validate_exchange_path(
+            decryptUrlParam(query[["countsdata"]])
+        )
+        data <- read.csv(inFile, check.names = FALSE)
         shinyjs::show(selector = "a[data-value=\"datainput\"]")
         shinyjs::disable("data_file_type")
         shinyjs::disable("datafile")
@@ -113,16 +116,6 @@ outputOptions(output, "fileUploaded", suspendWhenHidden = FALSE)
 observeEvent(input$nextInitParams, {
     js$collapse("iParamsbox")
 
-    organismsDbChoices <- c(
-        "Human (org.Hs.eg.db)" = "org.Hs.eg.db", "Mouse (org.Mm.eg.db)" = "org.Mm.eg.db", "Rat (org.Rn.eg.db)" = "org.Rn.eg.db",
-        "Yeast (org.Sc.sgd.db)" = "org.Sc.sgd.db", "Fly (org.Dm.eg.db)" = "org.Dm.eg.db", "Arabidopsis (org.At.tair.db)" = "org.At.tair.db",
-        "Zebrafish (org.Dr.eg.db)" = "org.Dr.eg.db", "Bovine (org.Bt.eg.db)" = "org.Bt.eg.db", "Worm (org.Ce.eg.db)" = "org.Ce.eg.db",
-        "Chicken (org.Gg.eg.db)" = "org.Gg.eg.db", "Canine (org.Cf.eg.db)" = "org.Cf.eg.db", "Pig (org.Ss.eg.db)" = "org.Ss.eg.db",
-        "Rhesus (org.Mmu.eg.db)" = "org.Mmu.eg.db", "E coli strain K12 (org.EcK12.eg.db)" = "org.EcK12.eg.db", "Xenopus (org.Xl.eg.db)" = "org.Xl.eg.db",
-        "Chimp (org.Pt.eg.db)" = "org.Pt.eg.db", "Anopheles (org.Ag.eg.db)" = "org.Ag.eg.db", "Malaria (org.Pf.plasmo.db)" = "org.Pf.plasmo.db",
-        "E coli strain Sakai (org.EcSakai.eg.db)" = "org.EcSakai.eg.db"
-    )
-
     updateSelectInput(session, "organismDb", choices = organismsDbChoices)
 
     if (input$data_file_type == "examplecounts") {
@@ -139,30 +132,17 @@ observeEvent(input$nextInitParams, {
 
 
 observeEvent(input$organismDb, {
-		req(input$organismDb)
-    #if (input$organismDb == "") {
-    #    return(NULL)
-    #}
-
-        if (!require(input$organismDb, character.only = TRUE)) {
-		print('not installed')
-		print(input$organismDb)
-	       withProgress(
-	                message = paste0("Installing package ",input$organismDb),
-	            detail = "This may take a while...",
-	            value = 0, {
-			 incProgress(0.4)
-		    	BiocManager::install(input$organismDb)
-					 incProgress(0.4) })
-
-
-	          
-
-	        }
-
-    library(input$organismDb, character.only = T)
-
-    annDb <- eval(parse(text = input$organismDb))
-    keytypes <- keytypes(annDb)
+    req(input$organismDb)
+    if (!requireNamespace(input$organismDb, quietly = TRUE)) {
+        showNotification(
+            paste("The selected annotation database is not installed:",
+                  input$organismDb),
+            type = "error",
+            duration = NULL
+        )
+        return()
+    }
+    annDb <- get(input$organismDb, envir = asNamespace(input$organismDb))
+    keytypes <- AnnotationDbi::keytypes(annDb)
     updateSelectInput(session, "keytype", choices = keytypes, selected = "ENSEMBL")
 })

--- a/ClusterProfShinyGSEA/src/server-plots.R
+++ b/ClusterProfShinyGSEA/src/server-plots.R
@@ -621,15 +621,20 @@ pathviewReactive <- eventReactive(input$generatePathview, {
         isolate({
             req(myValues$kegg_gene_list)
             tryCatch({
+                pathview_dir <- file.path(tempdir(check = TRUE), "pathview")
+                dir.create(pathview_dir, recursive = TRUE, showWarnings = FALSE)
+
                 setProgress(0.3, detail = paste0("Downloading pathway map \u2014 ", input$pathwayIds, " \u2026"))
                 dme <- pathview(
                     gene.data   = myValues$kegg_gene_list,
                     pathway.id  = input$pathwayIds,
                     species     = myValues$organismKegg,
-                    gene.idtype = "ENTREZ"
+                    gene.idtype = "ENTREZ",
+                    kegg.dir    = pathview_dir
                 )
-                unique_img <- paste0("testimage_", input$pathwayIds, ".png")
-                file.copy(paste0(input$pathwayIds, ".pathview.png"), unique_img, overwrite = TRUE)
+                native_img <- file.path(pathview_dir, paste0(input$pathwayIds, ".pathview.png"))
+                unique_img <- file.path(pathview_dir, paste0("testimage_", input$pathwayIds, ".png"))
+                file.copy(native_img, unique_img, overwrite = TRUE)
 
                 setProgress(0.7, detail = paste0("Generating PDF \u2014 ", input$pathwayIds, " \u2026"))
                 dmePdf <- pathview(
@@ -637,11 +642,19 @@ pathviewReactive <- eventReactive(input$generatePathview, {
                     pathway.id  = input$pathwayIds,
                     species     = myValues$organismKegg,
                     gene.idtype = "ENTREZ",
-                    kegg.native = FALSE
+                    kegg.native = FALSE,
+                    kegg.dir    = pathview_dir
                 )
 
-                myValues$imagePath <- paste0(input$pathwayIds, ".pathview.")
-                list(src = unique_img, filetype = "image/png", alt = "pathview image")
+                myValues$imagePath <- file.path(
+                    pathview_dir,
+                    paste0(input$pathwayIds, ".pathview.")
+                )
+                list(
+                    src = normalizePath(unique_img, mustWork = TRUE),
+                    filetype = "image/png",
+                    alt = "pathview image"
+                )
 
             }, error = function(e) {
                 msg <- conditionMessage(e)
@@ -688,19 +701,19 @@ outputOptions(output, "pathviewPlotsAvailable", suspendWhenHidden = FALSE)
 
 output$downloadPathviewPng <- downloadHandler(
     filename = function() {
-        paste0(myValues$imagePath, "png")
+        basename(paste0(myValues$imagePath, "png"))
     },
     content = function(file) {
-        file.copy(paste0(getwd(), "/", myValues$imagePath, "png"), file)
+        file.copy(paste0(myValues$imagePath, "png"), file)
     }
 )
 
 output$downloadPathviewPdf <- downloadHandler(
     filename = function() {
-        paste0(myValues$imagePath, "pdf")
+        basename(paste0(myValues$imagePath, "pdf"))
     },
     content = function(file) {
-        file.copy(paste0(getwd(), "/", myValues$imagePath, "pdf"), file)
+        file.copy(paste0(myValues$imagePath, "pdf"), file)
     }
 )
 

--- a/ClusterProfShinyGSEA/src/server-plots.R
+++ b/ClusterProfShinyGSEA/src/server-plots.R
@@ -161,7 +161,7 @@ output$genesInGoTerm <- plotly::renderPlotly({
                     shareX = TRUE, titleY = TRUE) %>%
         plotly::layout(plot_bgcolor = "#ffffff", paper_bgcolor = "#ffffff",
                        margin = list(l = 220), autosize = TRUE) %>%
-        plotly::config(responsive = TRUE) %>%
+        publication_plotly_config("gsea-go-gene-membership") %>%
         htmlwidgets::onRender("function(el) { setTimeout(function() { Plotly.Plots.resize(el); }, 300); }")
 })
 
@@ -726,7 +726,14 @@ output$pmcPlot <- renderPlotly({
                 if (is.null(terms)) {
                     return(NULL)
                 }
-                pmcplot(terms, seq(input$year_from, input$year_to), proportion = FALSE)
+                publication_plotly_config(
+                    pmcplot(
+                        terms,
+                        seq(input$year_from, input$year_to),
+                        proportion = FALSE
+                    ),
+                    "gsea-pubmed-trends"
+                )
             })
         }
     })

--- a/ClusterProfShinyGSEA/src/server.R
+++ b/ClusterProfShinyGSEA/src/server.R
@@ -3,6 +3,7 @@ options(shiny.maxRequestSize = 60 * 1024^2)
 
 # Define server
 server <- function(input, output, session) {
+    source("exchange-helpers.R", local = TRUE)
     source("plot-helpers.R",     local = TRUE)
     source("server-inputData.R", local = TRUE)
     #

--- a/ClusterProfShinyGSEA/src/test_exchange_helpers.R
+++ b/ClusterProfShinyGSEA/src/test_exchange_helpers.R
@@ -1,0 +1,18 @@
+source("exchange-helpers.R")
+
+path <- file.path(
+    nasqar_exchange_dir(create = TRUE),
+    "550e8400-e29b-41d4-a716-446655440001.csv"
+)
+write.csv(data.frame(gene = "g1"), path, row.names = FALSE)
+stopifnot(identical(validate_exchange_path(path), normalizePath(path)))
+
+failed <- FALSE
+tryCatch(
+    validate_exchange_path("/etc/passwd"),
+    error = function(error) failed <<- TRUE
+)
+stopifnot(failed)
+stopifnot(is.character(installed_organism_choices()))
+
+cat("GSEA exchange helper tests passed\n")

--- a/ClusterProfShinyGSEA/src/ui-tab-goplots.R
+++ b/ClusterProfShinyGSEA/src/ui-tab-goplots.R
@@ -1,107 +1,113 @@
 tabItem(
     tabName = "goplotsTab",
-    h2(strong("GO Plots")),
+    h2(strong("GO GSEA Plots")),
     uiOutput("goPlots_selectionBanner"),
     fluidRow(
         column(
-            3,
+            4,
             wellPanel(
-                numericInput("showCategory_go_global", "Number of categories to show", value = 5, min = 1),
-                tags$small(class = "text-muted", "Disabled when terms are selected in the gseGO tab.")
+                numericInput(
+                    "showCategory_go_global",
+                    "Number of gene sets to show",
+                    value = 5,
+                    min = 1
+                ),
+                tags$small(
+                    class = "text-muted",
+                    "Disabled when terms are selected in the gseGO table."
+                )
             )
         )
     ),
-    tags$div(
-        box(
-            title = "UpSet Plot (Interactive)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(
-                    12,
-                    wellPanel(
-                        plotly::plotlyOutput("genesInGoTerm", width = "100%", height = "500px"),
-                        uiOutput("go_clicked_genes_inline"),
-                        tags$hr(),
-                        h4(strong("Gene Membership")),
-                        dataTableOutput("genesGoMembershipTable")
-                    )
-                )
-            )
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Interactive gene membership",
+            "Intersection sizes and member genes for the displayed GO gene sets.",
+            plotly::plotlyOutput(
+                "genesInGoTerm",
+                width = "100%",
+                height = "520px"
+            ),
+            uiOutput("go_clicked_genes_inline"),
+            tags$hr(),
+            h4(strong("Gene membership")),
+            dataTableOutput("genesGoMembershipTable")
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Dot plot",
+            "Normalized enrichment scores and significance for GO gene sets.",
+            withSpinner(
+                plotOutput("dotPlot", height = "440px"),
+                type = 8
+            ),
+            plot_dl_buttons("dotPlot"),
+            width = 6
         ),
-        box(
-            title = "Dot Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "dotplot",
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "dotPlot"), type = 8),
-                    plot_dl_buttons("dotPlot")
-                ))
-            )
+        analysis_plot_panel(
+            "Ridge plot",
+            "Distribution of ranked gene statistics across enriched GO gene sets.",
+            withSpinner(
+                plotOutput("ridgePlot", height = "440px"),
+                type = 8
+            ),
+            plot_dl_buttons("ridgePlot"),
+            width = 6
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Enrichment map",
+            "Similarity network connecting GO gene sets with shared members.",
+            plotOutput("gsePlotMap", height = "620px"),
+            plot_dl_buttons("gsePlotMap")
         ),
-        box(
-            title = "Enrichment Plot Map", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "gsePlotMap",
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "gsePlotMap"),
-                    plot_dl_buttons("gsePlotMap")
-                ))
-            )
+        analysis_plot_panel(
+            "Category-gene network",
+            "Network linking enriched GO gene sets to their leading-edge genes.",
+            plotOutput("cnetplot", height = "620px"),
+            plot_dl_buttons("cnetplot")
         ),
-        box(
-            title = "Category Netplot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "cnetplot",
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "cnetplot"),
-                    plot_dl_buttons("cnetplot")
-                ))
-            )
+        analysis_plot_panel(
+            "GO term tree",
+            "Hierarchical clustering of enriched GO gene sets.",
+            numericInput(
+                "nCluster_tree",
+                "Number of clusters",
+                value = 5,
+                min = 2,
+                max = 20
+            ),
+            withSpinner(
+                plotOutput("treePlot", height = "620px"),
+                type = 8
+            ),
+            plot_dl_buttons("treePlot")
         ),
-        box(
-            title = "Tree Plot (hierarchical clustering of GO terms)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(3, wellPanel(
-                    numericInput("nCluster_tree", "Number of clusters", value = 5, min = 2, max = 20)
-                )),
-                column(9, wellPanel(
-                    withSpinner(plotOutput(outputId = "treePlot", height = "500px"), type = 8),
-                    plot_dl_buttons("treePlot")
-                ))
-            )
+        analysis_plot_panel(
+            "Gene-term heat plot",
+            "Ranked gene statistics across selected enriched GO gene sets.",
+            withSpinner(
+                plotOutput("heatPlot", height = "520px"),
+                type = 8
+            ),
+            plot_dl_buttons("heatPlot")
         ),
-        box(
-            title = "Heat Plot (gene-term associations)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "heatPlot", height = "400px"), type = 8),
-                    plot_dl_buttons("heatPlot")
-                ))
-            )
-        ),
-        box(
-            title = "Ridge Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "ridgeplot",
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "ridgePlot"), type = 8),
-                    plot_dl_buttons("ridgePlot")
-                ))
-            )
-        ),
-        box(
-            title = "GSEA Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "gseaplot",
-            fluidRow(
-                column(
-                    3,
-                    wellPanel(
-                        numericInput("geneSetId_gsea", "Gene Set ID (position in selected terms)", value = 1, min = 1)
-                    )
-                ),
-                column(
-                    9,
-                    wellPanel(
-                        plotOutput(outputId = "gseaplot", width = "100%", height = "400px"),
-                        plot_dl_buttons("gseaplot")
-                    )
-                )
-            )
-        ),
-        style = "display:table;"
+        analysis_plot_panel(
+            "Running enrichment score",
+            "Running-score curve and ranked-list position for the selected GO gene set.",
+            numericInput(
+                "geneSetId_gsea",
+                "Gene-set position",
+                value = 1,
+                min = 1
+            ),
+            plotOutput("gseaplot", width = "100%", height = "520px"),
+            plot_dl_buttons("gseaplot")
+        )
     )
 )

--- a/ClusterProfShinyGSEA/src/ui-tab-keggplots.R
+++ b/ClusterProfShinyGSEA/src/ui-tab-keggplots.R
@@ -1,110 +1,116 @@
 tabItem(
     tabName = "keggPlotsTab",
-    h2(strong("KEGG Plots")),
+    h2(strong("KEGG GSEA Plots")),
     uiOutput("keggPlots_selectionBanner"),
     fluidRow(
         column(
-            3,
+            4,
             wellPanel(
-                numericInput("showCategory_kegg_global", "Number of categories to show", value = 5, min = 1),
-                tags$small(class = "text-muted", "Disabled when pathways are selected in the gseKEGG tab.")
+                numericInput(
+                    "showCategory_kegg_global",
+                    "Number of pathways to show",
+                    value = 5,
+                    min = 1
+                ),
+                tags$small(
+                    class = "text-muted",
+                    "Disabled when pathways are selected in the gseKEGG table."
+                )
             )
         )
     ),
-    tags$div(
+    fluidRow(
+        class = "analysis-plot-row",
         conditionalPanel(
             "output.gseKEGGAvailable",
-            box(
-                title = "UpSet Plot (Interactive)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-                fluidRow(
-                    column(
-                        12,
-                        wellPanel(
-                            plotly::plotlyOutput("genesInKeggPathway", width = "100%", height = "500px"),
-                            uiOutput("kegg_clicked_genes_inline"),
-                            tags$hr(),
-                            h4(strong("Gene Membership")),
-                            dataTableOutput("genesKeggMembershipTable")
-                        )
-                    )
-                )
-            )
-        ),
-        box(
-            title = "Dot Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "dotplot_kegg",
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "dotPlot_kegg"), type = 8),
-                    plot_dl_buttons("dotPlot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Enrichment Plot Map", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "gsePlotMap_kegg",
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "gsePlotMap_kegg"),
-                    plot_dl_buttons("gsePlotMap_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Category Netplot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "cnetplot_kegg",
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "cnetplot_kegg", width = "100%", height = "400px"),
-                    plot_dl_buttons("cnetplot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Tree Plot (hierarchical clustering of KEGG pathways)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(3, wellPanel(
-                    numericInput("nCluster_tree_kegg", "Number of clusters", value = 5, min = 2, max = 20)
-                )),
-                column(9, wellPanel(
-                    withSpinner(plotOutput(outputId = "treePlot_kegg", height = "500px"), type = 8),
-                    plot_dl_buttons("treePlot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Heat Plot (gene-pathway associations)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "heatPlot_kegg", height = "400px"), type = 8),
-                    plot_dl_buttons("heatPlot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Ridge Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "ridgeplot_kegg",
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "ridgePlot_kegg"), type = 8),
-                    plot_dl_buttons("ridgePlot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "GSEA Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "gseaplot_kegg",
-            fluidRow(
-                column(
-                    3,
-                    wellPanel(
-                        numericInput("geneSetId_gsea_kegg", "Gene Set ID (position in selected pathways)", value = 1, min = 1)
-                    )
+            analysis_plot_panel(
+                "Interactive gene membership",
+                "Intersection sizes and genes for the displayed KEGG pathways.",
+                plotly::plotlyOutput(
+                    "genesInKeggPathway",
+                    width = "100%",
+                    height = "520px"
                 ),
-                column(
-                    9,
-                    wellPanel(
-                        plotOutput(outputId = "gseaplot_kegg", width = "100%", height = "400px"),
-                        plot_dl_buttons("gseaplot_kegg")
-                    )
-                )
+                uiOutput("kegg_clicked_genes_inline"),
+                tags$hr(),
+                h4(strong("Gene membership")),
+                dataTableOutput("genesKeggMembershipTable")
             )
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Dot plot",
+            "Normalized enrichment scores and significance for KEGG pathways.",
+            withSpinner(
+                plotOutput("dotPlot_kegg", height = "440px"),
+                type = 8
+            ),
+            plot_dl_buttons("dotPlot_kegg"),
+            width = 6
         ),
-        style = "display:table;"
+        analysis_plot_panel(
+            "Ridge plot",
+            "Distribution of ranked gene statistics across enriched pathways.",
+            withSpinner(
+                plotOutput("ridgePlot_kegg", height = "440px"),
+                type = 8
+            ),
+            plot_dl_buttons("ridgePlot_kegg"),
+            width = 6
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Enrichment map",
+            "Similarity network connecting KEGG pathways with shared genes.",
+            plotOutput("gsePlotMap_kegg", height = "620px"),
+            plot_dl_buttons("gsePlotMap_kegg")
+        ),
+        analysis_plot_panel(
+            "Category-gene network",
+            "Network linking enriched pathways to their leading-edge genes.",
+            plotOutput("cnetplot_kegg", width = "100%", height = "620px"),
+            plot_dl_buttons("cnetplot_kegg")
+        ),
+        analysis_plot_panel(
+            "KEGG pathway tree",
+            "Hierarchical clustering of enriched KEGG pathways.",
+            numericInput(
+                "nCluster_tree_kegg",
+                "Number of clusters",
+                value = 5,
+                min = 2,
+                max = 20
+            ),
+            withSpinner(
+                plotOutput("treePlot_kegg", height = "620px"),
+                type = 8
+            ),
+            plot_dl_buttons("treePlot_kegg")
+        ),
+        analysis_plot_panel(
+            "Gene-pathway heat plot",
+            "Ranked gene statistics across selected KEGG pathways.",
+            withSpinner(
+                plotOutput("heatPlot_kegg", height = "520px"),
+                type = 8
+            ),
+            plot_dl_buttons("heatPlot_kegg")
+        ),
+        analysis_plot_panel(
+            "Running enrichment score",
+            "Running-score curve and ranked-list position for the selected KEGG pathway.",
+            numericInput(
+                "geneSetId_gsea_kegg",
+                "Pathway position",
+                value = 1,
+                min = 1
+            ),
+            plotOutput("gseaplot_kegg", width = "100%", height = "520px"),
+            plot_dl_buttons("gseaplot_kegg")
+        )
     )
 )

--- a/ClusterProfShinyGSEA/src/ui.R
+++ b/ClusterProfShinyGSEA/src/ui.R
@@ -31,6 +31,22 @@ plot_dl_buttons <- function(plot_id) {
     )
 }
 
+analysis_plot_panel <- function(title, caption, ..., width = 12L,
+                                class = NULL) {
+    column(
+        width,
+        tags$section(
+            class = paste("analysis-plot-panel", class),
+            tags$header(
+                class = "analysis-plot-panel__header",
+                tags$h3(title)
+            ),
+            tags$div(class = "analysis-plot-panel__body", ...),
+            tags$footer(class = "analysis-plot-panel__caption", caption)
+        )
+    )
+}
+
 ui <- tagList(
     dashboardPage(
         #skin = "purple",

--- a/ClusterProfShinyGSEA/src/www/custom.css
+++ b/ClusterProfShinyGSEA/src/www/custom.css
@@ -388,3 +388,61 @@ a[bubbletooltip]:hover:after {
     background-color: white;
     box-shadow: inset 0px 0px 0px 1px lightgray;
 }
+
+.analysis-plot-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+}
+
+.analysis-plot-panel {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    height: calc(100% - 20px);
+    margin: 0 0 20px;
+    border: 1px solid #cfd6dc;
+    border-radius: 6px;
+    background: #fff;
+    overflow: hidden;
+}
+
+.analysis-plot-panel__header {
+    padding: 14px 18px;
+    border-bottom: 1px solid #dfe4e8;
+    background: #f5f7f8;
+}
+
+.analysis-plot-panel__header h3 {
+    margin: 0;
+    font-size: 20px;
+    line-height: 1.25;
+}
+
+.analysis-plot-panel__body {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 16px 18px;
+    overflow: hidden;
+}
+
+.analysis-plot-panel__body img,
+.analysis-plot-panel__body svg,
+.analysis-plot-panel__body .shiny-plot-output {
+    display: block;
+    max-width: 100%;
+}
+
+.analysis-plot-panel__caption {
+    padding: 11px 18px 14px;
+    border-top: 1px solid #e5e8eb;
+    color: #5d6873;
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+@media (max-width: 991px) {
+    .analysis-plot-row {
+        display: block;
+    }
+}

--- a/ClusterProfShinyORA/environment.yaml
+++ b/ClusterProfShinyORA/environment.yaml
@@ -19,3 +19,6 @@ dependencies:
   - r-plotly
   - bioconductor-clusterprofiler
   - bioconductor-pathview
+  - bioconductor-org.hs.eg.db
+  - bioconductor-org.mm.eg.db
+  - bioconductor-org.dm.eg.db

--- a/ClusterProfShinyORA/src/exchange-helpers.R
+++ b/ClusterProfShinyORA/src/exchange-helpers.R
@@ -1,0 +1,69 @@
+nasqar_exchange_dir <- function(create = FALSE) {
+    configured <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
+    path <- if (nzchar(configured)) {
+        configured
+    } else {
+        file.path(dirname(tempdir(check = TRUE)), "nasqar_exchange")
+    }
+    if (create) {
+        dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    }
+    normalizePath(path, mustWork = create)
+}
+
+validate_exchange_path <- function(path, extension = ".csv") {
+    if (!is.character(path) || length(path) != 1L || !nzchar(path)) {
+        stop("Invalid NASQAR2 exchange path.", call. = FALSE)
+    }
+
+    root <- nasqar_exchange_dir(create = TRUE)
+    resolved <- normalizePath(path, mustWork = TRUE)
+    prefix <- paste0(root, .Platform$file.sep)
+    uuid_file <- paste0(
+        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-",
+        "[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        gsub(".", "[.]", extension, fixed = TRUE),
+        "$"
+    )
+    if (!startsWith(resolved, prefix) ||
+        !grepl(uuid_file, basename(resolved))) {
+        stop("Exchange file is outside the NASQAR2 exchange directory.",
+             call. = FALSE)
+    }
+
+    info <- file.info(resolved)
+    if (is.na(info$isdir) || info$isdir || info$size > 600 * 1024^2) {
+        stop("Exchange file is invalid or too large.", call. = FALSE)
+    }
+    resolved
+}
+
+installed_organism_choices <- function() {
+    choices <- c(
+        "Human" = "org.Hs.eg.db",
+        "Mouse" = "org.Mm.eg.db",
+        "Rat" = "org.Rn.eg.db",
+        "Yeast" = "org.Sc.sgd.db",
+        "Fly" = "org.Dm.eg.db",
+        "Arabidopsis" = "org.At.tair.db",
+        "Zebrafish" = "org.Dr.eg.db",
+        "Bovine" = "org.Bt.eg.db",
+        "Worm" = "org.Ce.eg.db",
+        "Chicken" = "org.Gg.eg.db",
+        "Canine" = "org.Cf.eg.db",
+        "Pig" = "org.Ss.eg.db",
+        "Rhesus" = "org.Mmu.eg.db",
+        "E. coli K12" = "org.EcK12.eg.db",
+        "Xenopus" = "org.Xl.eg.db",
+        "Chimpanzee" = "org.Pt.eg.db",
+        "Anopheles" = "org.Ag.eg.db",
+        "Malaria parasite" = "org.Pf.plasmo.db",
+        "E. coli Sakai" = "org.EcSakai.eg.db"
+    )
+    choices[vapply(
+        unname(choices),
+        requireNamespace,
+        quietly = TRUE,
+        FUN.VALUE = logical(1)
+    )]
+}

--- a/ClusterProfShinyORA/src/plot-helpers.R
+++ b/ClusterProfShinyORA/src/plot-helpers.R
@@ -18,18 +18,40 @@ make_downloader <- function(output, plot_id, plot_fn, width = 10, height = 7) {
                 content  = function(file) {
                     switch(f,
                         png = grDevices::png(file,
-                                width  = round(width  * 150),
-                                height = round(height * 150),
-                                res    = 150),
-                        pdf = grDevices::pdf(file, width = width, height = height),
+                                width  = round(width  * 300),
+                                height = round(height * 300),
+                                res    = 300),
+                        pdf = grDevices::pdf(
+                                file, width = width, height = height,
+                                useDingbats = FALSE),
                         svg = grDevices::svg(file, width = width, height = height)
                     )
-                    tryCatch(print(plot_fn()), error = function(e) NULL)
-                    grDevices::dev.off()
+                    on.exit(grDevices::dev.off(), add = TRUE)
+                    print(plot_fn())
                 }
             )
         })
     }
+}
+
+publication_plotly_config <- function(
+    plot,
+    filename,
+    width = 2400,
+    height = 1600
+) {
+    plotly::config(
+        plot,
+        responsive = TRUE,
+        displaylogo = FALSE,
+        toImageButtonOptions = list(
+            format = "png",
+            filename = filename,
+            width = width,
+            height = height,
+            scale = 2
+        )
+    )
 }
 
 # ── KEGG KO ID converter ──────────────────────────────────────────────────────
@@ -138,7 +160,7 @@ build_ko_map <- function(entrez_ids, org) {
 plot_dl_buttons <- function(plot_id) {
     tags$div(
         style = "margin-top:6px;",
-        downloadButton(paste0("dl_", plot_id, "_png"), "PNG",
+        downloadButton(paste0("dl_", plot_id, "_png"), "PNG (300 DPI)",
                        class = "btn btn-xs btn-default"),
         tags$span("\u00a0"),
         downloadButton(paste0("dl_", plot_id, "_pdf"), "PDF",

--- a/ClusterProfShinyORA/src/server-enrichGo.R
+++ b/ClusterProfShinyORA/src/server-enrichGo.R
@@ -512,7 +512,7 @@ output$genesInKeggPathway <- plotly::renderPlotly({
             margin = list(l = 220),
             autosize = TRUE
         ) %>%
-        plotly::config(responsive = TRUE) %>%
+        publication_plotly_config("ora-kegg-gene-membership") %>%
         htmlwidgets::onRender("function(el) { setTimeout(function() { Plotly.Plots.resize(el); }, 300); }")
 })
 

--- a/ClusterProfShinyORA/src/server-inputData.R
+++ b/ClusterProfShinyORA/src/server-inputData.R
@@ -9,6 +9,7 @@ decryptUrlParam <- function(cipher) {
     unserialize(orig)
 }
 
+organismsDbChoices <- installed_organism_choices()
 
 observe({
     query <- parseQueryString(session$clientData$url_search)
@@ -40,21 +41,13 @@ inputDataReactive <- reactive({
             message = "Please select a file"
         )
     )
-    organismsDbChoices <- c(
-        "Human (org.Hs.eg.db)" = "org.Hs.eg.db", "Mouse (org.Mm.eg.db)" = "org.Mm.eg.db", "Rat (org.Rn.eg.db)" = "org.Rn.eg.db",
-        "Yeast (org.Sc.sgd.db)" = "org.Sc.sgd.db", "Fly (org.Dm.eg.db)" = "org.Dm.eg.db", "Arabidopsis (org.At.tair.db)" = "org.At.tair.db",
-        "Zebrafish (org.Dr.eg.db)" = "org.Dr.eg.db", "Bovine (org.Bt.eg.db)" = "org.Bt.eg.db", "Worm (org.Ce.eg.db)" = "org.Ce.eg.db",
-        "Chicken (org.Gg.eg.db)" = "org.Gg.eg.db", "Canine (org.Cf.eg.db)" = "org.Cf.eg.db", "Pig (org.Ss.eg.db)" = "org.Ss.eg.db",
-        "Rhesus (org.Mmu.eg.db)" = "org.Mmu.eg.db", "E coli strain K12 (org.EcK12.eg.db)" = "org.EcK12.eg.db", "Xenopus (org.Xl.eg.db)" = "org.Xl.eg.db",
-        "Chimp (org.Pt.eg.db)" = "org.Pt.eg.db", "Anopheles (org.Ag.eg.db)" = "org.Ag.eg.db", "Malaria (org.Pf.plasmo.db)" = "org.Pf.plasmo.db",
-        "E coli strain Sakai (org.EcSakai.eg.db)" = "org.EcSakai.eg.db"
-    )
-
     updateSelectInput(session, "organismDb", choices = organismsDbChoices)
     if (!is.null(query[["gene_names"]])) {
         print("null")
-        inFile <- decryptUrlParam(query[["gene_names"]])
-        data <- read.csv(inFile)
+        inFile <- validate_exchange_path(
+            decryptUrlParam(query[["gene_names"]])
+        )
+        data <- read.csv(inFile, check.names = FALSE)
         shinyjs::show(selector = "a[data-value=\"datainput\"]")
         # shinyjs::show(selector = "a[data-value=\"iParamsbox\"]")
         shinyjs::disable("datafile")
@@ -79,8 +72,10 @@ inputDataReactive <- reactive({
         # shinyjs::disable("iParamsbox")
         return(list("data" = data))
     } else if (!is.null(query[["countsdata"]])) {
-        inFile <- decryptUrlParam(query[["countsdata"]])
-        data <- read.csv(inFile)
+        inFile <- validate_exchange_path(
+            decryptUrlParam(query[["countsdata"]])
+        )
+        data <- read.csv(inFile, check.names = FALSE)
         shinyjs::show(selector = "a[data-value=\"datainput\"]")
 
         shinyjs::show(selector = "a[data-value=\"datainput\"]")
@@ -176,16 +171,6 @@ outputOptions(output, "fileUploaded", suspendWhenHidden = FALSE)
 observeEvent(input$nextInitParams, {
     js$collapse("iParamsbox")
 
-    organismsDbChoices <- c(
-        "Human (org.Hs.eg.db)" = "org.Hs.eg.db", "Mouse (org.Mm.eg.db)" = "org.Mm.eg.db", "Rat (org.Rn.eg.db)" = "org.Rn.eg.db",
-        "Yeast (org.Sc.sgd.db)" = "org.Sc.sgd.db", "Fly (org.Dm.eg.db)" = "org.Dm.eg.db", "Arabidopsis (org.At.tair.db)" = "org.At.tair.db",
-        "Zebrafish (org.Dr.eg.db)" = "org.Dr.eg.db", "Bovine (org.Bt.eg.db)" = "org.Bt.eg.db", "Worm (org.Ce.eg.db)" = "org.Ce.eg.db",
-        "Chicken (org.Gg.eg.db)" = "org.Gg.eg.db", "Canine (org.Cf.eg.db)" = "org.Cf.eg.db", "Pig (org.Ss.eg.db)" = "org.Ss.eg.db",
-        "Rhesus (org.Mmu.eg.db)" = "org.Mmu.eg.db", "E coli strain K12 (org.EcK12.eg.db)" = "org.EcK12.eg.db", "Xenopus (org.Xl.eg.db)" = "org.Xl.eg.db",
-        "Chimp (org.Pt.eg.db)" = "org.Pt.eg.db", "Anopheles (org.Ag.eg.db)" = "org.Ag.eg.db", "Malaria (org.Pf.plasmo.db)" = "org.Pf.plasmo.db",
-        "E coli strain Sakai (org.EcSakai.eg.db)" = "org.EcSakai.eg.db"
-    )
-
     updateSelectInput(session, "organismDb", choices = organismsDbChoices)
 
     if (input$data_file_type == "examplecounts") {
@@ -198,30 +183,17 @@ observeEvent(input$nextInitParams, {
 
 
 observeEvent(input$organismDb, {
-		    req(input$organismDb)
-    #if (input$organismDb == "") {
-    #    return(NULL)
-    #}
-
-            if (!require(input$organismDb, character.only = TRUE)) {
-		                    print('not installed')
-                    print(input$organismDb)
-		                   withProgress(
-						                        message = paste0("Installing package ",input$organismDb),
-									                    detail = "This may take a while...",
-									                    value = 0, {
-												                             incProgress(0.4)
-											                            BiocManager::install(input$organismDb)
-														                                             incProgress(0.4) })
-
-
-
-
-		                    }
-
-    library(input$organismDb, character.only = T)
-
-    annDb <- eval(parse(text = input$organismDb))
-    keytypes <- keytypes(annDb)
+    req(input$organismDb)
+    if (!requireNamespace(input$organismDb, quietly = TRUE)) {
+        showNotification(
+            paste("The selected annotation database is not installed:",
+                  input$organismDb),
+            type = "error",
+            duration = NULL
+        )
+        return()
+    }
+    annDb <- get(input$organismDb, envir = asNamespace(input$organismDb))
+    keytypes <- AnnotationDbi::keytypes(annDb)
     updateSelectInput(session, "keytype", choices = keytypes, selected = "ENSEMBL")
 })

--- a/ClusterProfShinyORA/src/server-plots.R
+++ b/ClusterProfShinyORA/src/server-plots.R
@@ -163,7 +163,7 @@ output$genesInGoTerm <- plotly::renderPlotly({
                     shareX = TRUE, titleY = TRUE) %>%
         plotly::layout(plot_bgcolor = "#ffffff", paper_bgcolor = "#ffffff",
                        margin = list(l = 220), autosize = TRUE) %>%
-        plotly::config(responsive = TRUE) %>%
+        publication_plotly_config("ora-go-gene-membership") %>%
         htmlwidgets::onRender("function(el) { setTimeout(function() { Plotly.Plots.resize(el); }, 300); }")
 })
 

--- a/ClusterProfShinyORA/src/server-plots.R
+++ b/ClusterProfShinyORA/src/server-plots.R
@@ -500,8 +500,8 @@ fc_to_hex <- function(fc_values, max_abs_fc = NULL) {
 }
 
 
-# Reactive: build the KEGG reference-map coloring URL for the selected pathway.
-# Format: map{id}/{KO_id}%09%23{hex}  e.g. map04130/K08513%09%23FBEAE9
+# Reactive: build the organism-specific KEGG coloring URL.
+# Organism gene IDs avoid a second REST request for KO conversion.
 keggColorUrl <- reactive({
     req(input$pathwayIds, myValues$kegg_gene_list)
     kegg_enrich <- enrichGoReactive()$kegg_enrich
@@ -518,23 +518,12 @@ keggColorUrl <- reactive({
     max_abs_fc <- max(abs(myValues$kegg_gene_list), na.rm = TRUE)
     bg_colors  <- fc_to_hex(gene_fcs, max_abs_fc)
 
-    # Convert ENTREZ IDs → KO IDs  (e.g. "38742" → "K08513")
     entrez_ids <- names(gene_fcs)
     org        <- myValues$organismKegg
-    ko_map     <- build_ko_map(entrez_ids, org)
-    ko_ids     <- ko_map[as.character(entrez_ids)]
-
-    # Drop genes with no KO assignment or empty KO string
-    valid      <- !is.na(ko_ids) & nzchar(ko_ids)
-    ko_ids     <- ko_ids[valid]
-    bg_colors  <- bg_colors[valid]
-    req(length(ko_ids) > 0)
-
-    # Use reference map ID: dme04080 → map04080
-    map_id <- sub("^[a-z]+", "map", input$pathwayIds)
-    parts  <- paste0(ko_ids, "%09%23", substring(bg_colors, 2))
+    kegg_ids   <- paste0(org, ":", entrez_ids)
+    parts      <- paste0(kegg_ids, "%09%23", substring(bg_colors, 2))
     paste0("https://www.kegg.jp/kegg-bin/show_pathway?",
-           map_id, "/",
+           input$pathwayIds, "/",
            paste(parts, collapse = "/"))
 })
 
@@ -598,15 +587,11 @@ pathwayGenesDf <- reactive({
             orig_ids <- orig_map[[keytype]][match(entrez_ids, orig_map$ENTREZID)]
     }
 
-    # ENTREZ → KO ID  (e.g. "38742" → "K08513")
-    ko_map   <- build_ko_map(entrez_ids, org)
-    kegg_ids <- ko_map[as.character(entrez_ids)]
-
     # Build data frame — insert original ID column right after Symbol when present
     df <- data.frame(Symbol = symbols, stringsAsFactors = FALSE)
     if (!is.null(orig_ids))
         df[[keytype]] <- orig_ids
-    df$KO_ID  <- kegg_ids
+    df$KEGG_ID <- paste0(org, ":", entrez_ids)
     df$ENTREZ <- entrez_ids
     df$Log2FC <- round(as.numeric(lfc_vals), 3)
 
@@ -670,16 +655,21 @@ pathviewReactive <- eventReactive(input$generatePathview, {
             req(myValues$kegg_gene_list)
 
             tryCatch({
+                pathview_dir <- file.path(tempdir(check = TRUE), "pathview")
+                dir.create(pathview_dir, recursive = TRUE, showWarnings = FALSE)
+
                 setProgress(0.3, detail = paste0("Downloading pathway map — ", input$pathwayIds, " \u2026"))
                 dme <- pathview(
                     gene.data   = myValues$kegg_gene_list,
                     pathway.id  = input$pathwayIds,
                     species     = myValues$organismKegg,
-                    gene.idtype = "ENTREZ"
+                    gene.idtype = "ENTREZ",
+                    kegg.dir    = pathview_dir
                 )
                 # Copy to a unique name so the UI preview refreshes each run
-                unique_img <- paste0("testimage_", input$pathwayIds, ".png")
-                file.copy(paste0(input$pathwayIds, ".pathview.png"), unique_img, overwrite = TRUE)
+                native_img <- file.path(pathview_dir, paste0(input$pathwayIds, ".pathview.png"))
+                unique_img <- file.path(pathview_dir, paste0("testimage_", input$pathwayIds, ".png"))
+                file.copy(native_img, unique_img, overwrite = TRUE)
 
                 setProgress(0.7, detail = paste0("Generating PDF \u2014 ", input$pathwayIds, " \u2026"))
                 dmePdf <- pathview(
@@ -687,11 +677,19 @@ pathviewReactive <- eventReactive(input$generatePathview, {
                     pathway.id  = input$pathwayIds,
                     species     = myValues$organismKegg,
                     gene.idtype = "ENTREZ",
-                    kegg.native = FALSE
+                    kegg.native = FALSE,
+                    kegg.dir    = pathview_dir
                 )
 
-                myValues$imagePath <- paste0(input$pathwayIds, ".pathview.")
-                list(src = unique_img, filetype = "image/png", alt = "pathview image")
+                myValues$imagePath <- file.path(
+                    pathview_dir,
+                    paste0(input$pathwayIds, ".pathview.")
+                )
+                list(
+                    src = normalizePath(unique_img, mustWork = TRUE),
+                    filetype = "image/png",
+                    alt = paste("Pathview overlay for", input$pathwayIds)
+                )
 
             }, error = function(e) {
                 msg <- conditionMessage(e)
@@ -728,7 +726,7 @@ output$pathview_plot <- renderImage({
     img <- pathviewReactive()
     req(!is.null(img))
     img
-})
+}, deleteFile = FALSE)
 
 output$pathviewPlotsAvailable <-
     reactive({
@@ -738,19 +736,19 @@ outputOptions(output, "pathviewPlotsAvailable", suspendWhenHidden = FALSE)
 
 output$downloadPathviewPng <- downloadHandler(
     filename = function() {
-        paste0(myValues$imagePath, "png")
+        basename(paste0(myValues$imagePath, "png"))
     },
     content = function(file) {
-        file.copy(paste0(getwd(), "/", myValues$imagePath, "png"), file)
+        file.copy(paste0(myValues$imagePath, "png"), file)
     }
 )
 
 output$downloadPathviewPdf <- downloadHandler(
     filename = function() {
-        paste0(myValues$imagePath, "pdf")
+        basename(paste0(myValues$imagePath, "pdf"))
     },
     content = function(file) {
-        file.copy(paste0(getwd(), "/", myValues$imagePath, "pdf"), file)
+        file.copy(paste0(myValues$imagePath, "pdf"), file)
     }
 )
 

--- a/ClusterProfShinyORA/src/server.R
+++ b/ClusterProfShinyORA/src/server.R
@@ -3,6 +3,7 @@ options(shiny.maxRequestSize = 60 * 1024^2)
 
 # Define server
 server <- function(input, output, session) {
+    source("exchange-helpers.R", local = TRUE)
     source("plot-helpers.R",    local = TRUE)
     source("server-inputData.R", local = TRUE)
     #

--- a/ClusterProfShinyORA/src/test_exchange_helpers.R
+++ b/ClusterProfShinyORA/src/test_exchange_helpers.R
@@ -1,0 +1,18 @@
+source("exchange-helpers.R")
+
+path <- file.path(
+    nasqar_exchange_dir(create = TRUE),
+    "550e8400-e29b-41d4-a716-446655440000.csv"
+)
+write.csv(data.frame(gene = "g1"), path, row.names = FALSE)
+stopifnot(identical(validate_exchange_path(path), normalizePath(path)))
+
+failed <- FALSE
+tryCatch(
+    validate_exchange_path("/etc/passwd"),
+    error = function(error) failed <<- TRUE
+)
+stopifnot(failed)
+stopifnot(is.character(installed_organism_choices()))
+
+cat("ORA exchange helper tests passed\n")

--- a/ClusterProfShinyORA/src/ui-tab-goplots.R
+++ b/ClusterProfShinyORA/src/ui-tab-goplots.R
@@ -4,101 +4,107 @@ tabItem(
     uiOutput("goPlots_selectionBanner"),
     fluidRow(
         column(
-            3,
+            4,
             wellPanel(
-                numericInput("showCategory_go_global", "Number of categories to show", value = 5, min = 1),
-                tags$small(class = "text-muted", "Disabled when terms are selected in the enrichGO tab.")
+                numericInput(
+                    "showCategory_go_global",
+                    "Number of categories to show",
+                    value = 5,
+                    min = 1
+                ),
+                tags$small(
+                    class = "text-muted",
+                    "Disabled when terms are selected in the enrichGO table."
+                )
             )
         )
     ),
-    tags$div(
-        box(
-            title = "UpSet Plot (Interactive)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(
-                    12,
-                    wellPanel(
-                        plotly::plotlyOutput("genesInGoTerm", width = "100%", height = "500px"),
-                        uiOutput("go_clicked_genes_inline"),
-                        tags$hr(),
-                        h4(strong("Gene Membership")),
-                        dataTableOutput("genesGoMembershipTable")
-                    )
-                )
-            )
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Interactive gene membership",
+            "Intersection sizes and member genes for the displayed GO terms.",
+            plotly::plotlyOutput(
+                "genesInGoTerm",
+                width = "100%",
+                height = "520px"
+            ),
+            uiOutput("go_clicked_genes_inline"),
+            tags$hr(),
+            h4(strong("Gene membership")),
+            dataTableOutput("genesGoMembershipTable")
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Bar plot",
+            "Enriched GO terms ranked by the selected significance measure.",
+            withSpinner(
+                plotOutput("barPlot", height = "420px"),
+                type = 8
+            ),
+            plot_dl_buttons("barPlot"),
+            width = 6
         ),
-        box(
-            title = "Bar Plot", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "barPlot"), type = 8),
-                    plot_dl_buttons("barPlot")
-                ))
-            )
+        analysis_plot_panel(
+            "Dot plot",
+            "GO term enrichment, gene ratio, and significance in a compact comparison.",
+            withSpinner(
+                plotOutput("dotPlot", height = "420px"),
+                type = 8
+            ),
+            plot_dl_buttons("dotPlot"),
+            width = 6
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Enrichment map",
+            "Similarity network connecting GO terms with overlapping gene sets.",
+            plotOutput("enrichPlotMap", height = "620px"),
+            plot_dl_buttons("enrichPlotMap")
         ),
-        box(
-            title = "Dot Plot", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "dotPlot"), type = 8),
-                    plot_dl_buttons("dotPlot")
-                ))
-            )
+        analysis_plot_panel(
+            "GO induced graph",
+            "Ontology graph showing relationships among selected enriched terms.",
+            plotOutput("goInducedGraph", height = "620px"),
+            plot_dl_buttons("goInducedGraph")
         ),
-        box(
-            title = "Enrichment Plot Map", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "enrichPlotMap"),
-                    plot_dl_buttons("enrichPlotMap")
-                ))
-            )
+        analysis_plot_panel(
+            "Category-gene network",
+            "Network linking enriched GO terms to the genes contributing to each term.",
+            plotOutput("cnetplot", width = "100%", height = "620px"),
+            plot_dl_buttons("cnetplot")
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "GO term tree",
+            "Hierarchical clustering of enriched GO terms by semantic similarity.",
+            numericInput(
+                "nCluster_tree",
+                "Number of clusters",
+                value = 5,
+                min = 2,
+                max = 20
+            ),
+            withSpinner(
+                plotOutput("treePlot", height = "620px"),
+                type = 8
+            ),
+            plot_dl_buttons("treePlot")
         ),
-        box(
-            title = "Category Netplot", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "goInducedGraph"),
-                    plot_dl_buttons("goInducedGraph")
-                ))
-            )
-        ),
-        box(
-            title = "Enriched GO induced graph (cnetplot)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "cnetplot", width = "100%", height = "400px"),
-                    plot_dl_buttons("cnetplot")
-                ))
-            )
-        ),
-        box(
-            title = "Tree Plot (hierarchical clustering of GO terms)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(
-                    3,
-                    wellPanel(
-                        numericInput("nCluster_tree", "Number of clusters", value = 5, min = 2, max = 20)
-                    )
-                ),
-                column(
-                    9,
-                    wellPanel(
-                        withSpinner(plotOutput(outputId = "treePlot", height = "500px"), type = 8),
-                        plot_dl_buttons("treePlot")
-                    )
-                )
-            )
-        ),
-        box(
-            title = "Heat Plot (gene-term associations)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "heatPlot", height = "400px"), type = 8),
-                    plot_dl_buttons("heatPlot")
-                ))
-            )
-        ),
-        style = "display:table;"
+        analysis_plot_panel(
+            "Gene-term heat plot",
+            "Gene-level fold changes across the selected enriched GO terms.",
+            withSpinner(
+                plotOutput("heatPlot", height = "520px"),
+                type = 8
+            ),
+            plot_dl_buttons("heatPlot")
+        )
     )
 )

--- a/ClusterProfShinyORA/src/ui-tab-keggplots.R
+++ b/ClusterProfShinyORA/src/ui-tab-keggplots.R
@@ -4,103 +4,101 @@ tabItem(
     uiOutput("keggPlots_selectionBanner"),
     fluidRow(
         column(
-            3,
+            4,
             wellPanel(
-                numericInput("showCategory_kegg_global", tags$span(
-                    "Number of categories to show ",
-                    tags$span(class = "help-tip",
-                        icon("question-circle"),
-                        tags$span(class = "help-tip-content",
-                            "Used when no rows are selected in the enrichKEGG tab. Shows top N pathways by p.adjust; q-value cutoff is still applied by the plot functions. When rows are manually selected this is disabled — q-value cutoff is bypassed so all selected pathways are plotted (p-value is already enforced by the results table)."
-                        )
-                    )
-                ), value = 5, min = 1),
-                tags$small(class = "text-muted", "Disabled when pathways are selected in the enrichKEGG tab.")
+                numericInput(
+                    "showCategory_kegg_global",
+                    "Number of pathways to show",
+                    value = 5,
+                    min = 1
+                ),
+                tags$small(
+                    class = "text-muted",
+                    "Disabled when pathways are selected in the enrichKEGG table."
+                )
             )
         )
     ),
-    tags$div(
+    fluidRow(
+        class = "analysis-plot-row",
         conditionalPanel(
             "output.enrichKEGGAvailable",
-            box(
-                title = "UpSet Plot (Interactive)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-                fluidRow(
-                    column(
-                        12,
-                        wellPanel(
-                            plotly::plotlyOutput("genesInKeggPathway", width = "100%", height = "500px"),
-                            uiOutput("kegg_clicked_genes_inline"),
-                            tags$hr(),
-                            h4(strong("Gene Membership")),
-                            dataTableOutput("genesKeggMembershipTable")
-                        )
-                    )
-                )
-            )
-        ),
-        box(
-            title = "Bar Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "barplot_kegg",
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "barPlot_kegg"), type = 8),
-                    plot_dl_buttons("barPlot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Dot Plot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "dotplot_kegg",
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "dotPlot_kegg"), type = 8),
-                    plot_dl_buttons("dotPlot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Enrichment Plot Map", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "enrichPlotMap_kegg_box",
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "enrichPlotMap_kegg"),
-                    plot_dl_buttons("enrichPlotMap_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Category Netplot", solidHeader = T, status = "danger", width = 12, collapsible = T, id = "cnetplot_kegg_box",
-            fluidRow(
-                column(12, wellPanel(
-                    plotOutput(outputId = "cnetplot_kegg", width = "100%", height = "400px"),
-                    plot_dl_buttons("cnetplot_kegg")
-                ))
-            )
-        ),
-        box(
-            title = "Tree Plot (hierarchical clustering of KEGG pathways)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(
-                    3,
-                    wellPanel(
-                        numericInput("nCluster_tree_kegg", "Number of clusters", value = 5, min = 2, max = 20)
-                    )
+            analysis_plot_panel(
+                "Interactive gene membership",
+                "Intersection sizes and member genes for the displayed KEGG pathways.",
+                plotly::plotlyOutput(
+                    "genesInKeggPathway",
+                    width = "100%",
+                    height = "520px"
                 ),
-                column(
-                    9,
-                    wellPanel(
-                        withSpinner(plotOutput(outputId = "treePlot_kegg", height = "500px"), type = 8),
-                        plot_dl_buttons("treePlot_kegg")
-                    )
-                )
+                uiOutput("kegg_clicked_genes_inline"),
+                tags$hr(),
+                h4(strong("Gene membership")),
+                dataTableOutput("genesKeggMembershipTable")
             )
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Bar plot",
+            "Enriched KEGG pathways ranked by the selected significance measure.",
+            withSpinner(
+                plotOutput("barPlot_kegg", height = "420px"),
+                type = 8
+            ),
+            plot_dl_buttons("barPlot_kegg"),
+            width = 6
         ),
-        box(
-            title = "Heat Plot (gene-pathway associations)", solidHeader = T, status = "danger", width = 12, collapsible = T,
-            fluidRow(
-                column(12, wellPanel(
-                    withSpinner(plotOutput(outputId = "heatPlot_kegg", height = "400px"), type = 8),
-                    plot_dl_buttons("heatPlot_kegg")
-                ))
-            )
+        analysis_plot_panel(
+            "Dot plot",
+            "KEGG pathway enrichment, gene ratio, and significance.",
+            withSpinner(
+                plotOutput("dotPlot_kegg", height = "420px"),
+                type = 8
+            ),
+            plot_dl_buttons("dotPlot_kegg"),
+            width = 6
+        )
+    ),
+    fluidRow(
+        class = "analysis-plot-row",
+        analysis_plot_panel(
+            "Enrichment map",
+            "Similarity network connecting KEGG pathways with overlapping genes.",
+            plotOutput("enrichPlotMap_kegg", height = "620px"),
+            plot_dl_buttons("enrichPlotMap_kegg")
         ),
-        style = "display:table;"
+        analysis_plot_panel(
+            "Category-gene network",
+            "Network linking enriched KEGG pathways to contributing genes.",
+            plotOutput("cnetplot_kegg", width = "100%", height = "620px"),
+            plot_dl_buttons("cnetplot_kegg")
+        ),
+        analysis_plot_panel(
+            "KEGG pathway tree",
+            "Hierarchical clustering of enriched pathways by gene-set similarity.",
+            numericInput(
+                "nCluster_tree_kegg",
+                "Number of clusters",
+                value = 5,
+                min = 2,
+                max = 20
+            ),
+            withSpinner(
+                plotOutput("treePlot_kegg", height = "620px"),
+                type = 8
+            ),
+            plot_dl_buttons("treePlot_kegg")
+        ),
+        analysis_plot_panel(
+            "Gene-pathway heat plot",
+            "Gene-level fold changes across selected KEGG pathways.",
+            withSpinner(
+                plotOutput("heatPlot_kegg", height = "520px"),
+                type = 8
+            ),
+            plot_dl_buttons("heatPlot_kegg")
+        )
     )
 )

--- a/ClusterProfShinyORA/src/ui.R
+++ b/ClusterProfShinyORA/src/ui.R
@@ -31,6 +31,22 @@ plot_dl_buttons <- function(plot_id) {
     )
 }
 
+analysis_plot_panel <- function(title, caption, ..., width = 12L,
+                                class = NULL) {
+    column(
+        width,
+        tags$section(
+            class = paste("analysis-plot-panel", class),
+            tags$header(
+                class = "analysis-plot-panel__header",
+                tags$h3(title)
+            ),
+            tags$div(class = "analysis-plot-panel__body", ...),
+            tags$footer(class = "analysis-plot-panel__caption", caption)
+        )
+    )
+}
+
 ui <- tagList(
     dashboardPage(
         #skin = "purple",

--- a/ClusterProfShinyORA/src/www/custom.css
+++ b/ClusterProfShinyORA/src/www/custom.css
@@ -389,3 +389,61 @@ a[bubbletooltip]:hover:after {
     background-color: white;
     box-shadow: inset 0px 0px 0px 1px lightgray;
 }
+
+.analysis-plot-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+}
+
+.analysis-plot-panel {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    height: calc(100% - 20px);
+    margin: 0 0 20px;
+    border: 1px solid #cfd6dc;
+    border-radius: 6px;
+    background: #fff;
+    overflow: hidden;
+}
+
+.analysis-plot-panel__header {
+    padding: 14px 18px;
+    border-bottom: 1px solid #dfe4e8;
+    background: #f5f7f8;
+}
+
+.analysis-plot-panel__header h3 {
+    margin: 0;
+    font-size: 20px;
+    line-height: 1.25;
+}
+
+.analysis-plot-panel__body {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 16px 18px;
+    overflow: hidden;
+}
+
+.analysis-plot-panel__body img,
+.analysis-plot-panel__body svg,
+.analysis-plot-panel__body .shiny-plot-output {
+    display: block;
+    max-width: 100%;
+}
+
+.analysis-plot-panel__caption {
+    padding: 11px 18px 14px;
+    border-top: 1px solid #e5e8eb;
+    color: #5d6873;
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+@media (max-width: 991px) {
+    .analysis-plot-row {
+        display: block;
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,10 @@ COPY SeuratV5Shiny /srv/shiny-server/SeuratV5Shiny
 COPY mergeFPKMs /srv/shiny-server/mergeFPKMs
 COPY tsar_nasqar /srv/shiny-server/tsar_nasqar
 
+# Gene Count Merger uses this at startup; install it into the immutable image.
+RUN conda run -n merged_env R -e \
+    "install.packages('shinythemes', repos='https://cloud.r-project.org/')"
+
 # Download and install BSgenome package
 RUN wget -q https://bioconductor.org/packages/release/data/annotation/src/contrib/BSgenome.Hsapiens.UCSC.hg19_1.4.3.tar.gz -O /BSgenome.Hsapiens.UCSC.hg19_1.4.3.tar.gz && \
     conda run -n merged_env R CMD INSTALL /BSgenome.Hsapiens.UCSC.hg19_1.4.3.tar.gz && \
@@ -82,6 +86,9 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Update supervisor configuration with correct path
 RUN sed -i 's|/opt/conda/envs/v_[^/]*|/opt/conda/envs/merged_env|g' /etc/supervisor/conf.d/supervisord.conf
+
+# Docker normally starts as root, but HPC containers run as the invoking user.
+RUN chmod -R a+rX /srv/shiny-server /usr/share/nginx/html /etc/nginx
 
 # Expose the port for the Nginx server
 EXPOSE 80

--- a/GeneCountMerger/src/app.R
+++ b/GeneCountMerger/src/app.R
@@ -1,10 +1,3 @@
-# Installl missing packages
-list.of.packages <- c("parallel", "shinythemes")
-new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[, "Package"])]
-if (length(new.packages)) {
-    install.packages(new.packages, repos = "https://cloud.r-project.org/", dependencies = T)
-}
-
 library(shiny)
 library(shinyBS)
 library(parallel)
@@ -226,7 +219,6 @@ ui <- tagList(
                                         tags$li(
                                             strong("Transcriptome Analysis (Optional)"), " – launch downstream analysis directly from the merged output:",
                                             tags$ul(
-                                                tags$li("Use our ", strong("Seurat Wizard"), " for single-cell RNA analysis"),
                                                 tags$li("Use ", strong("DESeq2Shiny"), " or ", strong("START"), " for bulk RNA analysis"),
                                                 tags$li("If there are ", strong("no replicates"), ", use DESeq2Shiny for exploratory analysis")
                                             )
@@ -416,19 +408,11 @@ ui <- tagList(
                                 div(style = "clear:both;"),
                                 tags$div(
                                     class = "BoxArea2",
-                                    p(strong("Start your analysis by launching the appropriate application for your data")),
+                                    p(strong("Continue with bulk RNA-seq analysis")),
                                     p(strong("Your merged counts data will be automatically loaded")),
                                     fluidRow(
                                         column(
-                                            4,
-                                            tags$div(
-                                                class = "BoxArea3", style = "text-align:center;",
-                                                p(strong("Single-Cell RNA")),
-                                                tags$span(class = "btn btn-success btn-sm", style = "width:100%; pointer-events:none;", "Seurat Wizard")
-                                            )
-                                        ),
-                                        column(
-                                            4,
+                                            6,
                                             tags$div(
                                                 class = "BoxArea3", style = "text-align:center;",
                                                 p(strong("Bulk RNA")),
@@ -438,7 +422,7 @@ ui <- tagList(
                                             )
                                         ),
                                         column(
-                                            4,
+                                            6,
                                             p(em("Buttons appear automatically after merging is complete."))
                                         )
                                     ),
@@ -707,45 +691,67 @@ server <- function(input, output, session) {
     })
 
 
+    handoffLink <- function(label, path, token, style = "width: 100%;") {
+        handoffPath <- paste0(path, "?countsdata=", token)
+        a(
+            label,
+            href = handoffPath,
+            `data-handoff-path` = handoffPath,
+            onclick = paste(
+                "this.href = window.location.origin +",
+                "this.getAttribute('data-handoff-path');"
+            ),
+            class = "btn btn-success",
+            target = "_blank",
+            style = style
+        )
+    }
+
     output$tab <- renderUI({
         if (is.null(myValues$fileUrl)) return(NULL)
+        if (is.null(myValues$startAppFileUrl)) return(NULL)
+        analysisCard <- tags$div(
+            class = "BoxArea3",
+            style = "text-align: center;",
+            p(strong("Bulk RNA")),
+            div(
+                class = "alert alert-info",
+                style = "text-align: left; font-size: 13px;",
+                p(
+                    style = "margin-bottom: 0;",
+                    strong("Gene columns: "),
+                    code("gene.ids"), " is required; ",
+                    code("gene.names"), " is optional. Neither column is",
+                    "treated as count data."
+                )
+            ),
+            h4(strong("DESeq2Shiny")),
+            p(
+                style = "text-align: left; font-size: 13px;",
+                "Define biological groups and contrasts using the sample",
+                "metadata uploaded in DESeq2Shiny."
+            ),
+            handoffLink(
+                "Open DESeq2Shiny",
+                "/deseq2shiny/",
+                encryptUrlParam(myValues$fileUrl)
+            ),
+            hr(),
+            h4(strong("START")),
+            div(
+                class = "alert alert-info",
+                style = "text-align: left; font-size: 13px;",
+                textOutput("startHandoffNote", inline = TRUE)
+            ),
+            uiOutput("startHandoffLink")
+        )
+
         tagList(
             h4(strong("Transcriptome Analysis (Optional):")),
-            p("Start your analysis by launching the appropriate application for your data"),
-            p("* If there are ", strong("NO replicates"), ", use DESeq2Shiny app for exploratory analysis"),
+            p("Continue to a compatible bulk RNA-seq application."),
             p(strong("Your merged counts data will be automatically loaded")),
             fluidRow(
-                column(8,
-                    style = "margin-left: 20%;",
-                    div(class = "BoxArea3 para", strong("Select Analysis Type:"))
-                )
-            ),
-            fluidRow(
-                column(8,
-                    offset = 2,
-                    div(class = "brace top")
-                )
-            ),
-            fluidRow(
-                column(
-                    6,
-                    tags$div(
-                        class = "BoxArea3", style = "text-align: center;",
-                        p(strong("Single-Cell RNA")),
-                        a("Seurat Wizard", href = paste0("/SeuratWizard?countsdata=", encryptUrlParam(myValues$fileUrl)), class = "btn btn-success", target = "_blank", style = "width: 100%;")
-                    )
-                ),
-                column(
-                    6,
-                    tags$div(
-                        class = "BoxArea3", style = "text-align: center;",
-                        p(strong("Bulk RNA")),
-                        a("DESeq2Shiny", href = paste0("/deseq2shiny?countsdata=", encryptUrlParam(myValues$fileUrl)), class = "btn btn-success", target = "_blank", style = "width: 100%;"),
-                        hr(),
-                        a("START", href = paste0("/tsar_nasqar?countsdata=", encryptUrlParam(myValues$startAppFileUrl)), class = "btn btn-success", target = "_blank", style = "width: 100%;")
-                    )
-                ),
-                div(style = "clear:both;")
+                column(10, offset = 1, analysisCard)
             )
         )
     })
@@ -973,38 +979,77 @@ server <- function(input, output, session) {
         {
             write.csv(myValues$mergedData, myValues$fileUrl, row.names = F)
 
-
-            # this is specific to STARTapp. need to add _1 when no replicates are present
-            myValues$startAppFileUrl <- gsub("\\.csv", "_startapp.csv", myValues$fileUrl)
-
-            mergedCountsOnly <- myValues$mergedData[, -1]
-            countsColStartIndex <- 2
-
-            if (class(mergedCountsOnly[, 1]) != "integer") {
-                mergedCountsOnly <- mergedCountsOnly[, -1]
-                countsColStartIndex <- 3
+            secondColumnName <- if (ncol(myValues$mergedData) >= 2L) {
+                tolower(gsub(
+                    "[^a-z0-9]",
+                    "",
+                    colnames(myValues$mergedData)[[2L]]
+                ))
+            } else {
+                ""
             }
+            hasSeparateGeneNames <- secondColumnName %in% c(
+                "genename", "genenames", "genesymbol", "symbol"
+            )
 
-            # mergedColNames = colnames(mergedCountsOnly)
-            #
-            # containsUnderscoreReplNum= grepl('_[0-9]+$',mergedColNames)
-            # if(!all(containsUnderscoreReplNum))
-            # {
-            #   #remove all underscores if present
-            #   mergedColNames = gsub("_","",mergedColNames)
-            #
-            #   #add underscore 1
-            #   mergedColNames = paste0(mergedColNames, "_1")
-            #
-            #   startappMergedDf = myValues$mergedData
-            #   colnames(startappMergedDf)[seq(countsColStartIndex,ncol(startappMergedDf))] = mergedColNames
-            #
-            #   write.csv(startappMergedDf, myValues$startAppFileUrl, row.names = F)
-            # }
-            # else
+            myValues$startAppFileUrl <- gsub(
+                "\\.csv$",
+                "_startapp.csv",
+                myValues$fileUrl
+            )
             write.csv(myValues$mergedData, myValues$startAppFileUrl, row.names = F)
+
+            identifierColumnCount <- if (hasSeparateGeneNames) 2L else 1L
+            startSampleNames <- colnames(myValues$mergedData)[
+                -(seq_len(identifierColumnCount))
+            ]
+            validStartNames <- grepl(
+                "^[A-Za-z0-9.-]+_[0-9]+$",
+                startSampleNames
+            )
+            startGroups <- sub("_[0-9]+$", "", startSampleNames)
+            replicatedGroups <- length(startGroups) > 0L &&
+                all(table(startGroups) >= 2L)
+            myValues$startHandoffReady <- length(startSampleNames) >= 2L &&
+                all(validStartNames) &&
+                replicatedGroups
+            myValues$startHandoffNote <- if (isTRUE(
+                myValues$startHandoffReady
+            )) {
+                paste(
+                    "Ready. Sample columns use GROUP_REPLICATE names and",
+                    "each group has at least two biological replicates."
+                )
+            } else {
+                paste(
+                    "START requires GROUP_REPLICATE sample names such as",
+                    "WT_1, WT_2, HET_1, and HET_2.",
+                    "Use Edit Column Names before launching START."
+                )
+            }
         }
     )
+
+    output$startHandoffNote <- renderText({
+        req(myValues$startHandoffNote)
+        myValues$startHandoffNote
+    })
+
+    output$startHandoffLink <- renderUI({
+        req(!is.null(myValues$startHandoffReady))
+        if (!isTRUE(myValues$startHandoffReady)) {
+            return(tags$span(
+                class = "btn btn-default disabled",
+                style = "width: 100%;",
+                "START unavailable: rename samples as GROUP_REPLICATE"
+            ))
+        }
+        handoffLink(
+            "START",
+            "/tsar_nasqar/",
+            encryptUrlParam(myValues$startAppFileUrl)
+        )
+    })
 
     multmerge <- function(inFiles, sep, isMultiple) {
         filenames <- inFiles$datapath
@@ -1098,15 +1143,39 @@ server <- function(input, output, session) {
 
         # Import via tximport (type = "kallisto", TSV format).
         # abundance.tsv columns: target_id, length, eff_length, est_counts, tpm
+        # Kallisto indices built from Gencode FASTA files may append metadata
+        # after "|" while Ensembl mappings may differ only by version suffix.
+        first_targets <- read.delim(
+            files[[1]],
+            nrows = 100,
+            stringsAsFactors = FALSE,
+            check.names = FALSE
+        )$target_id
+        primary_targets <- sub("\\|.*$", "", first_targets)
+        mapping_targets <- as.character(tx2gene[[1]])
+        exact_matches <- sum(primary_targets %in% mapping_targets)
+        version_matches <- sum(
+            sub("\\.[0-9]+$", "", primary_targets) %in%
+                sub("\\.[0-9]+$", "", mapping_targets)
+        )
+        ignore_after_bar <- any(grepl("|", first_targets, fixed = TRUE))
+        ignore_tx_version <- exact_matches == 0 && version_matches > 0
+
         txi <- tximport::tximport(
             files,
             type            = "kallisto",
             tx2gene         = tx2gene,
-            ignoreTxVersion = TRUE
+            ignoreTxVersion = ignore_tx_version,
+            ignoreAfterBar  = ignore_after_bar,
+            countsFromAbundance = "lengthScaledTPM"
         )
 
-        # Convert estimated counts to data.frame (preserving decimal values)
-        counts_mat <- txi$counts
+        # Export bias-corrected gene-level counts that can be used without a
+        # transcript-length offset by matrix-based downstream applications.
+        # DESeq2's tximport constructor rounds abundance-derived estimates before
+        # constructing the integer count matrix. Apply the same single rounding
+        # step here so the downloaded matrix is accepted by matrix-based tools.
+        counts_mat <- round(txi$counts)
         df         <- as.data.frame(counts_mat, stringsAsFactors = FALSE)
         df         <- cbind(gene.ids = rownames(df), df)
         rownames(df) <- NULL
@@ -1129,8 +1198,23 @@ server <- function(input, output, session) {
         #   1. Custom upload → read user-supplied CSV
         #   2. Pre-built     → load from refGenome .Rda
         if (isTRUE(input$geneNamesSource == "custom")) {
-            geneid2name <- read.csv2(input$gtfMappingFile$datapath, sep = ",",
-                                     colClasses = c("character", "character"))
+            mappingPath <- input$gtfMappingFile$datapath
+            validate(need(
+                length(mappingPath) == 1L && nzchar(mappingPath),
+                "Upload the custom GENE_ID/GENE_NAME mapping before merging."
+            ))
+            geneid2name <- read.csv(
+                mappingPath,
+                header = TRUE,
+                colClasses = c("character", "character"),
+                strip.white = TRUE
+            )
+            validate(need(
+                ncol(geneid2name) >= 2L,
+                "The custom mapping must contain GENE_ID and GENE_NAME columns."
+            ))
+            geneid2name <- geneid2name[, 1:2, drop = FALSE]
+            colnames(geneid2name) <- c("GENE_ID", "GENE_NAME")
         } else {
             load(paste0("www/gene_names/", input$refGenome, ".Rda"))
         }
@@ -1154,26 +1238,15 @@ server <- function(input, output, session) {
         #   annoDb <- org.Hs.eg.db
 
 
-        # Calculate the number of cores
-        no_cores <- detectCores() - 1
-
-        # Initiate cluster
-        # cl <- makeCluster(no_cores)
-        cl <- makeForkCluster(no_cores)
-
         print(paste(format(Sys.time(), "%H:%M:%OS3"), ": Started Renaming ", length(ensNames), " genes"))
-        # levelsList = character(length(ensNames))
-        levelsList <- parallel::parLapply(cl, ensNames, function(x) {
-            # return(ids[geneid2name$GENE_ID == as.character(x),]$GENE_NAME)
-            return(geneid2name[geneid2name$GENE_ID == as.character(x), ]$GENE_NAME)
-        })
-
+        mappingIndex <- match(
+            as.character(ensNames),
+            as.character(geneid2name$GENE_ID)
+        )
+        flatList <- as.character(geneid2name$GENE_NAME[mappingIndex])
         print(paste(format(Sys.time(), "%H:%M:%OS3"), ": Finished renaming"))
-        stopCluster(cl)
 
         progress$set(value = 0.8)
-
-        flatList <- unlist(levelsList)
 
         progress$set(value = 1)
         return(flatList)
@@ -1183,12 +1256,20 @@ server <- function(input, output, session) {
 
 
     output$filesUploaded <- reactive({
+        geneNamesReady <- !isTRUE(input$addGeneNames) ||
+            !isTRUE(input$geneNamesSource == "custom") ||
+            (
+                !is.null(input$gtfMappingFile) &&
+                length(input$gtfMappingFile$datapath) == 1L &&
+                nzchar(input$gtfMappingFile$datapath)
+            )
+
         if (isTRUE(input$inputType == "kallisto")) {
             h5Ready      <- !is.null(input$kallistoFiles)
             tx2geneReady <- isTRUE(input$tx2geneSource == "prebuilt") || !is.null(input$tx2geneFile)
-            return(h5Ready && tx2geneReady)
+            return(h5Ready && tx2geneReady && geneNamesReady)
         }
-        return(!is.null(inputDataReactive()))
+        return(!is.null(inputDataReactive()) && geneNamesReady)
     })
     outputOptions(output, "filesUploaded", suspendWhenHidden = FALSE)
 

--- a/GeneCountMerger/src/app.R
+++ b/GeneCountMerger/src/app.R
@@ -7,6 +7,64 @@ library(uuid)
 library(readr)
 library(tximport)
 
+merge_count_frames <- function(frames) {
+    if (!is.list(frames) || length(frames) == 0L) {
+        stop("At least one count table is required.", call. = FALSE)
+    }
+
+    frames <- lapply(seq_along(frames), function(index) {
+        frame <- as.data.frame(frames[[index]], check.names = FALSE)
+        if (!"gene.ids" %in% names(frame)) {
+            stop(sprintf("Count table %d has no gene.ids column.", index),
+                 call. = FALSE)
+        }
+        identifiers <- trimws(as.character(frame$gene.ids))
+        if (anyNA(identifiers) || any(!nzchar(identifiers))) {
+            stop(sprintf("Count table %d contains an empty gene identifier.",
+                         index),
+                 call. = FALSE)
+        }
+        duplicated_ids <- unique(identifiers[duplicated(identifiers)])
+        if (length(duplicated_ids) > 0L) {
+            stop(
+                sprintf(
+                    "Count table %d contains duplicate gene identifiers: %s",
+                    index,
+                    paste(utils::head(duplicated_ids, 5L), collapse = ", ")
+                ),
+                call. = FALSE
+            )
+        }
+        frame$gene.ids <- identifiers
+        frame
+    })
+
+    sample_names <- unlist(lapply(frames, function(frame) {
+        setdiff(names(frame), "gene.ids")
+    }), use.names = FALSE)
+    duplicated_samples <- unique(sample_names[duplicated(sample_names)])
+    if (length(duplicated_samples) > 0L) {
+        stop(
+            sprintf(
+                "Sample column names must be unique across files: %s",
+                paste(duplicated_samples, collapse = ", ")
+            ),
+            call. = FALSE
+        )
+    }
+
+    merged <- Reduce(
+        function(left, right) {
+            merge(left, right, by = "gene.ids", all = TRUE, sort = FALSE)
+        },
+        frames
+    )
+    count_columns <- setdiff(names(merged), "gene.ids")
+    for (column in count_columns) {
+        merged[[column]][is.na(merged[[column]])] <- 0
+    }
+    merged[order(merged$gene.ids), , drop = FALSE]
+}
 
 
 ui <- tagList(
@@ -707,11 +765,22 @@ server <- function(input, output, session) {
         )
     }
 
+    nasqarExchangeDir <- function() {
+        configured <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
+        path <- if (nzchar(configured)) {
+            configured
+        } else {
+            file.path(dirname(tempdir(check = TRUE)), "nasqar_exchange")
+        }
+        dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+        normalizePath(path, mustWork = TRUE)
+    }
+
     output$tab <- renderUI({
         if (is.null(myValues$fileUrl)) return(NULL)
         if (is.null(myValues$startAppFileUrl)) return(NULL)
         analysisCard <- tags$div(
-            class = "BoxArea3",
+            class = "BoxArea3 analysis-handoff-card",
             style = "text-align: center;",
             p(strong("Bulk RNA")),
             div(
@@ -961,8 +1030,10 @@ server <- function(input, output, session) {
                 }
 
 
-                myValues$fileUrl <- UUIDgenerate()
-                myValues$fileUrl <- paste0(tempdir(), "/", myValues$fileUrl, ".csv")
+                myValues$fileUrl <- file.path(
+                    nasqarExchangeDir(),
+                    paste0(UUIDgenerate(), ".csv")
+                )
 
                 updateTabsetPanel(session, "tabs", selected = "Output")
 
@@ -1039,9 +1110,13 @@ server <- function(input, output, session) {
         req(!is.null(myValues$startHandoffReady))
         if (!isTRUE(myValues$startHandoffReady)) {
             return(tags$span(
-                class = "btn btn-default disabled",
-                style = "width: 100%;",
-                "START unavailable: rename samples as GROUP_REPLICATE"
+                class = paste(
+                    "btn btn-default disabled",
+                    "analysis-handoff-button"
+                ),
+                role = "button",
+                `aria-disabled` = "true",
+                "START unavailable"
             ))
         }
         handoffLink(
@@ -1059,7 +1134,8 @@ server <- function(input, output, session) {
 
         useHeader <- isTRUE(input$hasHeader)
 
-        datalist <- lapply(filenames, function(x) {
+        datalist <- lapply(seq_along(filenames), function(file_index) {
+            x <- filenames[[file_index]]
             fileContent <- read.csv(file = x, header = useHeader, sep = sep)
 
             n <- ncol(fileContent)
@@ -1079,7 +1155,13 @@ server <- function(input, output, session) {
             }
 
             colnames(fileContent)[1] <- "gene.ids"
-            fileContent <- fileContent[!grepl("__", fileContent[, 1]), ] # remove rows containing underscores
+            if (!isMultiple) {
+                colnames(fileContent)[2] <- tools::file_path_sans_ext(
+                    inFiles$name[[file_index]]
+                )
+            }
+            # HTSeq summary records are named __no_feature, __ambiguous, etc.
+            fileContent <- fileContent[!grepl("^__", fileContent[, 1]), ]
 
             # Sort by gene_id incase they are not sorted
             fileContent <- fileContent[order(fileContent[, 1]), ]
@@ -1087,19 +1169,8 @@ server <- function(input, output, session) {
             fileContent
         })
 
-        reduced <- Reduce(function(x, y) {
-            merge(x, y, by = "gene.ids")
-        }, datalist)
+        reduced <- merge_count_frames(datalist)
 
-
-
-        if (!isMultiple) {
-            samplenames <- unlist(lapply(inFiles$name, function(x) {
-                tools::file_path_sans_ext(x)
-            }))
-
-            colnames(reduced) <- c("gene.ids", samplenames)
-        }
 
 
         return(reduced)

--- a/GeneCountMerger/src/test_merge_counts.R
+++ b/GeneCountMerger/src/test_merge_counts.R
@@ -1,0 +1,38 @@
+source("app.R")
+
+first <- data.frame(
+    gene.ids = c("gene_a", "gene_b"),
+    sample_1 = c(10, 20),
+    check.names = FALSE
+)
+second <- data.frame(
+    gene.ids = c("gene_b", "gene_c"),
+    sample_2 = c(30, 40),
+    check.names = FALSE
+)
+
+merged <- merge_count_frames(list(first, second))
+stopifnot(
+    identical(merged$gene.ids, c("gene_a", "gene_b", "gene_c")),
+    identical(merged$sample_1, c(10, 20, 0)),
+    identical(merged$sample_2, c(0, 30, 40))
+)
+
+expect_error <- function(expression) {
+    raised <- FALSE
+    tryCatch(
+        force(expression),
+        error = function(error) raised <<- TRUE
+    )
+    stopifnot(raised)
+}
+
+expect_error(merge_count_frames(list(
+    data.frame(gene.ids = c("gene_a", "gene_a"), sample_1 = c(1, 2))
+)))
+expect_error(merge_count_frames(list(
+    first,
+    data.frame(gene.ids = "gene_c", sample_1 = 3)
+)))
+
+cat("Gene Count Merger regression tests passed\n")

--- a/GeneCountMerger/src/www/custom.css
+++ b/GeneCountMerger/src/www/custom.css
@@ -110,3 +110,31 @@
 body {
   font-size: 16px;
 }
+
+.analysis-handoff-card {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.analysis-handoff-card .alert,
+.analysis-handoff-card p,
+.analysis-handoff-card code {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.analysis-handoff-button {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  height: auto;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+  text-align: center;
+}

--- a/SeuratV5Shiny/src/server-download.R
+++ b/SeuratV5Shiny/src/server-download.R
@@ -11,7 +11,8 @@ observe({
       pbmc <- myValues$finalData$pbmc
       filename = paste0(input$projectname,"_seuratObj_",session$token,"_", format(Sys.time(), "%y-%m-%d_%H-%M-%S"), '.rds')
 
-      filepath = file.path(tempdir(), filename)
+      output_dir <- seurat_project_directory(input$projectname)
+      filepath = file.path(output_dir, filename)
       cat(filepath)
       shiny::setProgress(value = 0.3, detail = "might take some time for large datasets ...")
 
@@ -20,6 +21,11 @@ observe({
       #v3
       saveRDS(pbmc, file = filepath)
       myValues$filepath <- filepath
+      myValues$hpcOutputPath <- if (nzchar(Sys.getenv("NASQAR_SEURAT_PROJECT_DIR", ""))) {
+        filepath
+      } else {
+        NULL
+      }
 
       js$addStatusIcon("finishTab","done")
     })
@@ -37,6 +43,11 @@ output$seuratFileExists <-
   })
 outputOptions(output, 'seuratFileExists', suspendWhenHidden=FALSE)
 
+output$hpcSeuratPath <- renderText({
+  req(myValues$hpcOutputPath)
+  paste("Saved persistently on HPC:", myValues$hpcOutputPath)
+})
+
 
 
 output$downloadRObj <- downloadHandler(
@@ -51,6 +62,43 @@ output$downloadRObj <- downloadHandler(
     js$addStatusIcon("finishTab","done")
   }
 )
+
+monocle_exchange_token <- reactiveVal(NULL)
+
+output$monocleTransferUI <- renderUI({
+  req(myValues$finalData$pbmc)
+
+  token <- monocle_exchange_token()
+  if (is.null(token)) {
+    exchange_dir <- file.path(tempdir(check = TRUE), "..", "nasqar_exchange")
+    exchange_dir <- normalizePath(exchange_dir, mustWork = FALSE)
+    dir.create(exchange_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    token <- uuid::UUIDgenerate()
+    saveRDS(
+      myValues$finalData$pbmc,
+      file.path(exchange_dir, paste0(token, ".rds"))
+    )
+    monocle_exchange_token(token)
+  }
+
+  handoffPath <- paste0(
+    "/monocle3/?exchange=",
+    URLencode(token, reserved = TRUE)
+  )
+
+  tags$a(
+    icon("project-diagram"),
+    "Open directly in Monocle3",
+    href = handoffPath,
+    `data-handoff-path` = handoffPath,
+    onclick = paste(
+      "this.href = window.location.origin +",
+      "this.getAttribute('data-handoff-path');"
+    ),
+    target = "_blank",
+    class = "button button-3d button-block button-pill button-primary button-large"
+  )
+})
 
 
 generateSeuratScript <- function(filepath)

--- a/SeuratV5Shiny/src/server-findMarkers.R
+++ b/SeuratV5Shiny/src/server-findMarkers.R
@@ -36,7 +36,7 @@ findClusterMarkersReactive <- eventReactive(input$findClusterMarkers, {
      
     #jay
     #plan("multiprocess", workers = 3)
-    plan("multisession", workers =3)
+    plan("multisession", workers = nasqar_seurat_workers)
     cluster.markers <- FindMarkers(object = pbmc, ident.1 = input$clusterNum, min.pct = input$minPct, test.use = input$testuse, only.pos = input$onlypos)
     
     myValues$scriptCommands$findMarkers = paste0("cluster.markers <- FindMarkers(object = pbmc, ident.1 = ",input$clusterNum,", min.pct = ",input$minPct,", test.use = ",input$testuse,", only.pos = ",input$onlypos,")")
@@ -97,7 +97,7 @@ findClusterMarkersVSReactive <- eventReactive(input$findClusterMarkersVS, {
     shiny::setProgress(value = 0.4, detail = "Finding cluster markers ...")
     #jay
     #plan("multiprocess", workers = 3)
-    plan("multisession", workers =3)
+    plan("multisession", workers = nasqar_seurat_workers)
     cluster.markers <- FindMarkers(object = pbmc, ident.1 = input$clusterNumVS1, ident.2 = input$clusterNumVS2, min.pct = input$minPctvs, test.use = input$testuseVS, only.pos = input$onlyposVS)
     
     myValues$scriptCommands$findMarkers = paste0("cluster.markersVS <- FindMarkers(object = pbmc, ident.1 = ",input$clusterNumVS1,", ident.2 = ",input$clusterNumVS2,", min.pct = ",input$minPctvs,", test.use = ",input$testuseVS,", only.pos = ",input$onlyposVS,")")
@@ -159,7 +159,7 @@ findClusterMarkersAllReactive <- eventReactive(input$findClusterMarkersAll, {
     shiny::setProgress(value = 0.4, detail = "Finding cluster markers ...")
     #jay
     #plan("multiprocess", workers = 3)
-      plan("multisession", workers =3)
+      plan("multisession", workers = nasqar_seurat_workers)
     cluster.markers <- FindAllMarkers(object = pbmc, min.pct = input$minPctAll, test.use = input$testuseAll, only.pos = input$onlyposAll, logfc.threshold = input$threshAll)
     
     myValues$scriptCommands$findAllMarkers = paste0("cluster.markers <- FindAllMarkers(object = pbmc, min.pct = ",input$minPctAll,", test.use = '",input$testuseAll,"', only.pos = ",input$onlyposAll,", logfc.threshold = ",input$threshAll,")")

--- a/SeuratV5Shiny/src/server-initInputData.R
+++ b/SeuratV5Shiny/src/server-initInputData.R
@@ -30,7 +30,7 @@ inputDataReactive <- reactive({
 
   # Check if example selected, or if not then ask to upload a file.
   shiny:: validate(
-    need( identical(input$data_file_type,"examplecounts")|(!is.null(input$datafile))|(!is.null(query[['countsdata']])),
+    need( identical(input$data_file_type,"examplecounts")|identical(input$data_file_type,"hpcScratch")|(!is.null(input$datafile))|(!is.null(query[['countsdata']])),
          message = "Please select a file")
   )
 
@@ -59,6 +59,39 @@ inputDataReactive <- reactive({
   validate(need(
     tryCatch({
       scriptCommands = c()
+
+      if (identical(input$data_file_type, "hpcScratch")) {
+        req(input$load_hpc_data > 0)
+        validate(need(nzchar(trimws(input$hpc_data_path)), "Enter an HPC data path."))
+        hpc_path <- resolve_hpc_path(input$hpc_data_path)
+        js$addStatusIcon("datainput", "loading")
+        if (dir.exists(hpc_path)) {
+          seqdata <- Read10X(data.dir = hpc_path)
+          scriptCommands$readCounts <- sprintf(
+            "counts.data <- Read10X(data.dir = %s)",
+            dQuote(hpc_path)
+          )
+        } else {
+          separator <- if (grepl("\\.(tsv|txt)(\\.gz)?$", hpc_path, ignore.case = TRUE)) "\t" else ","
+          seqdata <- read.csv(
+            hpc_path,
+            header = TRUE,
+            sep = separator,
+            row.names = 1,
+            check.names = FALSE
+          )
+          validate(need(ncol(seqdata) > 1L, "The HPC count matrix must contain at least two cell columns."))
+          scriptCommands$readCounts <- sprintf(
+            "counts.data <- read.csv(%s, header=TRUE, sep=%s, row.names=1)",
+            dQuote(hpc_path),
+            dQuote(separator)
+          )
+        }
+        isolate(myValues$scriptCommands <- scriptCommands)
+        js$addStatusIcon("datainput", "done")
+        js$collapse("uploadbox")
+        return(list(data = seqdata))
+      }
       
       if (!is.null(inFile) && !is.null(query[['countsdata']])) {
         #js$addStatusIcon("datainput","loading")

--- a/SeuratV5Shiny/src/server-jackStraw.R
+++ b/SeuratV5Shiny/src/server-jackStraw.R
@@ -21,7 +21,7 @@ jackStrawReactive <-
       #v3
       #jay
       #plan("multiprocess", workers = 3)
-      plan("multisession", workers =3)
+      plan("multisession", workers = nasqar_seurat_workers)
       pbmc <- JackStraw(object = pbmc, num.replicate = input$numReplicates)
       pbmc <- ScoreJackStraw(object = pbmc, dims = input$jsPcsToPlot1:input$jsPcsToPlot2)
       

--- a/SeuratV5Shiny/src/server-normSelect.R
+++ b/SeuratV5Shiny/src/server-normSelect.R
@@ -96,7 +96,7 @@ sctransformReactive <-
       shiny::setProgress(value = 0.4, detail = "Running SCTransform ...")
       #jay
       #plan("multiprocess", workers = 3)
-      plan("multisession", workers =3)
+      plan("multisession", workers = nasqar_seurat_workers)
       pbmc <- SCTransform(object = pbmc, verbose = F, vars.to.regress = input$varsToRegressUmap)
       
       myValues$scriptCommands$sctransform = paste0("pbmc <- SCTransform(object = pbmc, vars.to.regress = ",vectorToStr(input$varsToRegressUmap),")")

--- a/SeuratV5Shiny/src/server-tsne.R
+++ b/SeuratV5Shiny/src/server-tsne.R
@@ -14,7 +14,7 @@ tsneReactive <-
 
       shiny::setProgress(value = 0.4, detail = "Running TSNE Reduction ...")
 
-      pbmc <- RunTSNE(object = pbmc, dims.use = as.numeric(c(input$tsnePCDim)), perplexity = input$tsnePerplexity, num_threads = parallel::detectCores()/2)
+      pbmc <- RunTSNE(object = pbmc, dims.use = as.numeric(c(input$tsnePCDim)), perplexity = input$tsnePerplexity, num_threads = nasqar_seurat_workers)
 
       updateSelectizeInput(session,'clusterNumCells',
                            choices=levels(pbmc), selected=NULL)
@@ -193,7 +193,6 @@ observe({
   if(input$nextDownload > 0 || input$nextDownloadUmap > 0)
     GotoTab("finishTab")
 })
-
 
 
 

--- a/SeuratV5Shiny/src/server.R
+++ b/SeuratV5Shiny/src/server.R
@@ -3,10 +3,39 @@
 options(shiny.maxRequestSize = 400*1024^2)
 options(future.globals.maxSize = 3000 * 1024 ^ 2)
 library(future)
-#plan("multiprocess", workers = 2)
-plan("multisession", workers =2)
+nasqar_seurat_workers <- suppressWarnings(
+  as.integer(Sys.getenv("SLURM_CPUS_PER_TASK", "1"))
+)
+if (is.na(nasqar_seurat_workers) || nasqar_seurat_workers < 1L) {
+  nasqar_seurat_workers <- 1L
+}
+plan("multisession", workers = nasqar_seurat_workers)
 
 server <- function(input, output, session) {
+  resolve_hpc_path <- function(path) {
+    root <- normalizePath(
+      Sys.getenv("NASQAR_DATA_ROOT", unset = "/scratch/nr83"),
+      mustWork = TRUE
+    )
+    resolved <- normalizePath(path, mustWork = TRUE)
+    allowed <- identical(resolved, root) ||
+      startsWith(resolved, paste0(root, .Platform$file.sep))
+    if (!allowed) stop("The path must be inside the configured HPC data root.")
+    resolved
+  }
+
+  seurat_project_directory <- function(name) {
+    root <- Sys.getenv("NASQAR_SEURAT_PROJECT_DIR", unset = "")
+    if (!nzchar(root)) return(tempdir())
+    safe_name <- gsub("[^A-Za-z0-9._-]+", "-", trimws(name))
+    if (!nzchar(safe_name)) safe_name <- "seurat-project"
+    path <- file.path(root, safe_name)
+    dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    if (!dir.exists(path) || file.access(path, 2) != 0) {
+      stop("The Seurat HPC project directory is not writable.")
+    }
+    path
+  }
 
   source("server-initInputData.R",local = TRUE)
 

--- a/SeuratV5Shiny/src/ui-tab-finish.R
+++ b/SeuratV5Shiny/src/ui-tab-finish.R
@@ -24,8 +24,19 @@ tabItem(tabName = "finishTab",
                        "output.seuratFileExists",
                        downloadButton('downloadRObj', 'Download Seurat Obj', class = "button button-3d button-block button-pill button-action button-large")
                      )
-                   )
+                   ),
+                   textOutput("hpcSeuratPath")
              ),
+            column(
+              12,
+              conditionalPanel(
+                "output.seuratFileExists",
+                hr(),
+                h4(strong("Continue trajectory analysis")),
+                p("In the all-in-one deployment, open this Seurat object directly in Monocle3."),
+                uiOutput("monocleTransferUI")
+              )
+            ),
             column(12,
                    hr(),
                    p("Generate and Download the R script to reproduce these steps in R/RStudio"),

--- a/SeuratV5Shiny/src/ui-tab-inputdata.R
+++ b/SeuratV5Shiny/src/ui-tab-inputdata.R
@@ -4,13 +4,24 @@ tabItem(tabName = "datainput",
                          box(title = "Upload Data", solidHeader = T, status = "primary", width = 12, collapsible = T,id = "uploadbox",
 
                              #downloadLink("instructionspdf",label="Download Instructions (pdf)"),
-                             radioButtons('data_file_type','Use example file or upload your own data',
+                             radioButtons('data_file_type','Select count data source',
                                           c(
                                             #'Upload Data (Dropseq)'="uploadDropseq",
                                             'Upload Data (nonUMI)'="uploadNonUmi",
                                             'Upload Data (10X)'="upload10x",
-                                            'Example Data (PBMC)'="examplecounts"
+                                            'Example Data (PBMC)'="examplecounts",
+                                            'Use HPC scratch path'="hpcScratch"
                                           ),selected = "uploadNonUmi"),
+                             conditionalPanel(
+                               condition="input.data_file_type=='hpcScratch'",
+                               textInput(
+                                 "hpc_data_path",
+                                 "10X directory or CSV/TSV count matrix inside HPC scratch",
+                                 value = ""
+                               ),
+                               actionButton("load_hpc_data", "Load HPC Data", class = "btn btn-primary"),
+                               helpText("The input is read directly; it is not copied through the browser.")
+                             ),
                              conditionalPanel(condition="input.data_file_type=='upload10x'",
                                               p("10X Data, 1 .mtx.gz file, and 2 .tsv.gz files")
                                               #fileInput('datafile', 'Choose File Containing Data (.mtx, .tsv)', multiple = TRUE)

--- a/animalcules/src/server/server_01_upload.R
+++ b/animalcules/src/server/server_01_upload.R
@@ -12,6 +12,7 @@ vals <- reactiveValues(
     MAE = readRDS(data_dir),
     MAE_backup = MAE
 )
+nasqar_transfer_status <- reactiveVal(NULL)
 
 observeEvent(input$upload_example,{
   withBusyIndicatorServer("upload_example", {
@@ -39,9 +40,165 @@ update_inputs <- function(session) {
     updateOrganisms(session)
 }
 
+read_nasqar_exchange <- function(token) {
+    validate(need(
+        length(token) == 1L && grepl("^[0-9a-fA-F-]{36}$", token),
+        "Invalid NASQAR2 transfer token."
+    ))
+    exchange_dir <- file.path(tempdir(check = TRUE), "..", "nasqar_exchange")
+    exchange_dir <- normalizePath(exchange_dir, mustWork = FALSE)
+    path <- file.path(exchange_dir, paste0(token, ".rds"))
+    validate(need(file.exists(path), "The transferred DADA2 result has expired."))
+    validate(need(
+        as.numeric(difftime(Sys.time(), file.info(path)$mtime, units = "secs")) <= 3600,
+        "The transferred DADA2 result has expired."
+    ))
+    exchange <- readRDS(path)
+    attr(exchange, "nasqar_exchange_path") <- path
+    exchange
+}
+
+mae_from_dada2_exchange <- function(exchange) {
+    validate(need(
+        is.list(exchange) &&
+            all(c("counts", "taxonomy", "metadata") %in% names(exchange)),
+        "The DADA2 transfer is incomplete."
+    ))
+
+    counts <- as.data.frame(exchange$counts, check.names = FALSE)
+    taxonomy <- as.data.frame(exchange$taxonomy, check.names = FALSE)
+    metadata <- as.data.frame(exchange$metadata, check.names = FALSE)
+    validate(need(
+        identical(colnames(counts), rownames(metadata)),
+        "DADA2 sample names do not match the transferred metadata."
+    ))
+    validate(need(
+        identical(rownames(counts), rownames(taxonomy)),
+        "DADA2 ASV names do not match the transferred taxonomy."
+    ))
+
+    se_mgx <- counts %>%
+        base::data.matrix() %>%
+        S4Vectors::SimpleList() %>%
+        magrittr::set_names("MGX")
+    se_colData <- metadata %>% S4Vectors::DataFrame()
+    se_rowData <- taxonomy %>%
+        dplyr::mutate_all(as.character) %>%
+        S4Vectors::DataFrame()
+    microbe_se <- SummarizedExperiment::SummarizedExperiment(
+        assays = se_mgx,
+        colData = se_colData,
+        rowData = se_rowData
+    )
+    MultiAssayExperiment::MultiAssayExperiment(
+        experiments = S4Vectors::SimpleList(MicrobeGenetics = microbe_se),
+        colData = se_colData
+    )
+}
+
+observeEvent(TRUE, {
+    query <- parseQueryString(session$clientData$url_search)
+    if (!is.null(query[["exchange"]])) {
+        tryCatch({
+            exchange <- read_nasqar_exchange(query[["exchange"]])
+            exchange_path <- attr(exchange, "nasqar_exchange_path")
+            transferred_mae <- mae_from_dada2_exchange(exchange)
+            microbe <- transferred_mae[["MicrobeGenetics"]]
+
+            vals$MAE <- transferred_mae
+            vals$MAE_backup <- transferred_mae
+            update_inputs(session)
+            updateTabsetPanel(
+                session,
+                "Animalcules",
+                selected = "Summary and Filter"
+            )
+            nasqar_transfer_status(list(
+                type = "success",
+                samples = ncol(microbe),
+                features = nrow(microbe),
+                has_groups = any(vapply(
+                    as.data.frame(SummarizedExperiment::colData(microbe)),
+                    function(column) {
+                        level_count <- length(unique(column[!is.na(column)]))
+                        level_count > 1 && level_count < ncol(microbe)
+                    },
+                    logical(1)
+                ))
+            ))
+            unlink(exchange_path)
+            showNotification(
+                sprintf(
+                    "Loaded %d ASVs across %d samples from DADA2Shiny.",
+                    nrow(microbe),
+                    ncol(microbe)
+                ),
+                type = "message",
+                duration = NULL
+            )
+        }, error = function(e) {
+            message_text <- conditionMessage(e)
+            if (!nzchar(message_text)) {
+                message_text <- "Animalcules could not import the DADA2 dataset."
+            }
+            nasqar_transfer_status(list(
+                type = "error",
+                message = message_text
+            ))
+            showNotification(
+                paste(
+                    message_text,
+                    "The transfer was retained so it can be retried."
+                ),
+                type = "error",
+                duration = NULL
+            )
+        })
+    }
+}, once = TRUE)
+
+output$nasqar_transfer_status <- renderUI({
+    status <- nasqar_transfer_status()
+    req(status)
+    if (identical(status$type, "success")) {
+        tags$div(
+            class = "alert alert-success",
+            tags$strong("DADA2 dataset loaded"),
+            tags$br(),
+            sprintf(
+                "%d ASVs across %d samples are active in animalcules.",
+                status$features,
+                status$samples
+            ),
+            if (!isTRUE(status$has_groups)) {
+                tagList(
+                    tags$br(),
+                    "No biological grouping metadata was transferred. ",
+                    "Taxonomy and per-sample analyses are available; ",
+                    "group comparisons require sample metadata."
+                )
+            }
+        )
+    } else {
+        tags$div(
+            class = "alert alert-danger",
+            tags$strong("DADA2 import failed"),
+            tags$br(),
+            status$message
+        )
+    }
+})
+
 updateCovariate <- function(session){
     MAE <- vals$MAE
     covariates <- colnames(colData(MAE))
+    sample_count <- nrow(colData(MAE))
+    informative <- vapply(covariates, function(covariate) {
+        values <- colData(MAE)[[covariate]]
+        num.levels <- length(unique(values[!is.na(values)]))
+        num.levels > 1 && num.levels < sample_count
+    }, logical(1))
+    covariates <- covariates[informative]
     # use experience to choose categorical variables
     covariates.colorbar <- c()
     covariates_remove_index <- NULL

--- a/animalcules/src/server/server_01_upload.R
+++ b/animalcules/src/server/server_01_upload.R
@@ -45,8 +45,13 @@ read_nasqar_exchange <- function(token) {
         length(token) == 1L && grepl("^[0-9a-fA-F-]{36}$", token),
         "Invalid NASQAR2 transfer token."
     ))
-    exchange_dir <- file.path(tempdir(check = TRUE), "..", "nasqar_exchange")
-    exchange_dir <- normalizePath(exchange_dir, mustWork = FALSE)
+    configured_exchange <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
+    exchange_dir <- if (nzchar(configured_exchange)) {
+        configured_exchange
+    } else {
+        file.path(dirname(tempdir(check = TRUE)), "nasqar_exchange")
+    }
+    exchange_dir <- normalizePath(exchange_dir, mustWork = TRUE)
     path <- file.path(exchange_dir, paste0(token, ".rds"))
     validate(need(file.exists(path), "The transferred DADA2 result has expired."))
     validate(need(

--- a/animalcules/src/server/server_02_filter.R
+++ b/animalcules/src/server/server_02_filter.R
@@ -1,6 +1,7 @@
 ## Filter by metadata
 output$filter_metadata_params <- renderUI({
 
+    req(input$filter_type_metadata)
     MAE <- vals$MAE
     microbe <- MAE[['MicrobeGenetics']]
     sam_table <- as.data.frame(colData(microbe)) # sample x condition
@@ -167,10 +168,12 @@ output$download_biom <- downloadHandler(filename = function() {
 
 ## Categorize
 output$filter_nbins <- renderUI({
+    req(input$filter_bin_cov)
     MAE <- vals$MAE
     microbe <- MAE[['MicrobeGenetics']]
     sam_table <- as.data.frame(colData(microbe)) # sample x condition
     vals <- unlist(sam_table[,input$filter_bin_cov,drop=TRUE])
+    req(length(unique(vals[!is.na(vals)])) >= 2)
     sliderInput("filter_nbins", label="Number of Bins", min=2, max=length(unique(vals)), value=2, step=1)
 })
 output$filter_bin_to1 <- renderPrint({
@@ -350,7 +353,6 @@ output$download_assay_annot <- downloadHandler(filename = function() {
   df.out <- find_assay_annot()
   write.csv(df.out, file)
 })
-
 
 
 

--- a/animalcules/src/ui/ui_01_upload.R
+++ b/animalcules/src/ui/ui_01_upload.R
@@ -13,6 +13,7 @@ tags$div(
 
     )
 ),
+uiOutput("nasqar_transfer_status"),
 sidebarLayout(
     sidebarPanel(
         tags$span(style="color:#72bcd4", "Application Settings"),

--- a/dada2Shiny/src/analysis-helpers.R
+++ b/dada2Shiny/src/analysis-helpers.R
@@ -1,0 +1,96 @@
+nasqar_exchange_dir <- function(create = FALSE) {
+    configured <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
+    path <- if (nzchar(configured)) {
+        configured
+    } else {
+        file.path(dirname(tempdir(check = TRUE)), "nasqar_exchange")
+    }
+    if (create) {
+        dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    }
+    normalizePath(path, mustWork = create)
+}
+
+align_sample_metadata <- function(metadata, sample_names) {
+    metadata <- as.data.frame(metadata, check.names = FALSE)
+    if (is.null(rownames(metadata)) ||
+        !setequal(sample_names, rownames(metadata))) {
+        stop("Metadata sample names must match the DADA2 sample names.",
+             call. = FALSE)
+    }
+    metadata[sample_names, , drop = FALSE]
+}
+
+top_taxa_names <- function(abundance, limit = 20L) {
+    taxa_names <- names(abundance)
+    abundance <- as.numeric(abundance)
+    names(abundance) <- taxa_names
+    if (length(abundance) == 0L) {
+        return(character())
+    }
+    ordered <- names(sort(abundance, decreasing = TRUE))
+    utils::head(ordered, min(as.integer(limit), length(ordered)))
+}
+
+draw_publication_plot <- function(plot_function) {
+    plot_object <- plot_function()
+    if (inherits(plot_object, c("gg", "ggplot", "grob", "gTree", "gtable"))) {
+        print(plot_object)
+    }
+    invisible(plot_object)
+}
+
+register_publication_downloads <- function(
+    output,
+    id,
+    filename,
+    plot_function,
+    width = 8,
+    height = 6
+) {
+    formats <- list(
+        png = list(
+            extension = "png",
+            content_type = "image/png",
+            open = function(file) {
+                grDevices::png(
+                    file,
+                    width = width,
+                    height = height,
+                    units = "in",
+                    res = 300,
+                    type = if (capabilities("cairo")) "cairo" else getOption("bitmapType")
+                )
+            }
+        ),
+        pdf = list(
+            extension = "pdf",
+            content_type = "application/pdf",
+            open = function(file) {
+                grDevices::pdf(file, width = width, height = height, useDingbats = FALSE)
+            }
+        ),
+        svg = list(
+            extension = "svg",
+            content_type = "image/svg+xml",
+            open = function(file) grDevices::svg(file, width = width, height = height)
+        )
+    )
+
+    for (format in names(formats)) {
+        config <- formats[[format]]
+        local({
+            local_format <- format
+            local_config <- config
+            output[[paste0(id, "_", local_format)]] <- shiny::downloadHandler(
+                filename = function() paste0(filename(), ".", local_config$extension),
+                contentType = local_config$content_type,
+                content = function(file) {
+                    local_config$open(file)
+                    on.exit(grDevices::dev.off(), add = TRUE)
+                    draw_publication_plot(plot_function)
+                }
+            )
+        })
+    }
+}

--- a/dada2Shiny/src/server-alphaDiversity.R
+++ b/dada2Shiny/src/server-alphaDiversity.R
@@ -13,6 +13,50 @@ qiimeData <- reactive({
     # }
 })
 
+metadataColumns <- reactive({
+    metadata <- as.data.frame(qiimeData(), check.names = FALSE)
+    names(metadata)
+})
+
+output$alphaDiversityMappings <- renderUI({
+    req(input$sampleData)
+    columns <- metadataColumns()
+    req(length(columns) > 0L)
+    taxonomy <- reactiveTaxonomyData$taxa
+    taxonomy_ranks <- if (is.null(taxonomy)) character() else colnames(taxonomy)
+
+    tagList(
+        selectInput(
+            "alpha_x",
+            "Sample grouping (x-axis)",
+            choices = columns,
+            selected = columns[[1L]]
+        ),
+        selectInput(
+            "alpha_color",
+            "Sample color",
+            choices = c("None" = "", columns),
+            selected = ""
+        ),
+        selectInput(
+            "alpha_facet",
+            "Composition panels",
+            choices = c("None" = "", columns),
+            selected = ""
+        ),
+        selectInput(
+            "alpha_tax_rank",
+            "Taxonomy rank",
+            choices = taxonomy_ranks,
+            selected = if ("Family" %in% taxonomy_ranks) {
+                "Family"
+            } else {
+                utils::tail(taxonomy_ranks, 1L)
+            }
+        )
+    )
+})
+
 
 
 # Reactive expression to load the sample metadata
@@ -41,9 +85,29 @@ observeEvent(input$runAlphaDiversity, {
     alphaDiversityResults$ps.top20 <- NULL
     
     req(qiimeData())
+    req(input$alpha_x, input$alpha_tax_rank)
 
     seqtab.nochim <- reactiveInputData()$seqtab.nochim
     taxa <- reactiveTaxonomyData$taxa
+    sample_metadata <- as.data.frame(qiimeData(), check.names = FALSE)
+    sample_metadata <- tryCatch(
+        align_sample_metadata(sample_metadata, rownames(seqtab.nochim)),
+        error = function(error) {
+            shiny::validate(need(FALSE, conditionMessage(error)))
+        }
+    )
+    shiny::validate(
+        need(nrow(seqtab.nochim) > 0L && ncol(seqtab.nochim) > 0L,
+             "The DADA2 count table is empty."),
+        need(all(rowSums(seqtab.nochim) > 0),
+             "Every sample must contain at least one non-chimeric read."),
+        need(nrow(taxa) > 0L,
+             "Assign taxonomy before running diversity analysis."),
+        need(
+            input$alpha_tax_rank %in% colnames(taxa),
+            "Select an available taxonomy rank."
+        )
+    )
 
     # print(qiimeData())
 
@@ -76,10 +140,12 @@ observeEvent(input$runAlphaDiversity, {
 
     ps <- phyloseq(
         otu_table(seqtab.nochim, taxa_are_rows = FALSE),
-        sample_data(qiimeData()),
+        sample_data(sample_metadata),
         tax_table(taxa)
     )
-    ps <- prune_samples(sample_names(ps) != "Mock", ps) # Remove mock sample
+    if ("Mock" %in% sample_names(ps)) {
+        ps <- prune_samples(sample_names(ps) != "Mock", ps)
+    }
 
 
     dna <- Biostrings::DNAStringSet(taxa_names(ps))
@@ -92,7 +158,11 @@ observeEvent(input$runAlphaDiversity, {
     ord.nmds.bray <- ordinate(ps.prop, method = "NMDS", distance = "bray")
 
 
-    top20 <- names(sort(taxa_sums(ps), decreasing = TRUE))[1:20]
+    top20 <- top_taxa_names(taxa_sums(ps), 20L)
+    shiny::validate(need(
+        length(top20) > 0L,
+        "No taxa are available for the composition plot."
+    ))
     ps.top20 <- transform_sample_counts(ps, function(OTU) OTU / sum(OTU))
     ps.top20 <- prune_taxa(top20, ps.top20)
     
@@ -117,26 +187,67 @@ observeEvent(input$runAlphaDiversity, {
 })
 
 # Reactive plot outputs that depend on stored results
-output$plotAlphaDiversity <- renderPlot({
+alpha_diversity_plot <- reactive({
     req(alphaDiversityResults$ps)
     req(divergen_done())
-    plot_richness(alphaDiversityResults$ps, x = "Day", measures = c("Shannon", "Simpson"), color = "When")
+    color_column <- if (nzchar(input$alpha_color)) input$alpha_color else NULL
+    plot_richness(
+        alphaDiversityResults$ps,
+        x = input$alpha_x,
+        measures = c("Shannon", "Simpson"),
+        color = color_column
+    )
 })
 
-output$plotOrdination <- renderPlot({
+ordination_plot <- reactive({
     req(alphaDiversityResults$ps.prop)
     req(alphaDiversityResults$ord.nmds.bray)
     req(divergen_done())
-    plot_ordination(alphaDiversityResults$ps.prop, alphaDiversityResults$ord.nmds.bray, 
-                    color = "When", title = "Bray NMDS")
+    color_column <- if (nzchar(input$alpha_color)) input$alpha_color else NULL
+    plot_ordination(
+        alphaDiversityResults$ps.prop,
+        alphaDiversityResults$ord.nmds.bray,
+        color = color_column,
+        title = "Bray-Curtis NMDS"
+    )
 })
 
-output$plotBar <- renderPlot({
+composition_plot <- reactive({
     req(alphaDiversityResults$ps.top20)
     req(divergen_done())
-    plot_bar(alphaDiversityResults$ps.top20, x = "Day", fill = "Family") + 
-        facet_wrap(~When, scales = "free_x")
+    plot <- plot_bar(
+        alphaDiversityResults$ps.top20,
+        x = input$alpha_x,
+        fill = input$alpha_tax_rank
+    )
+    if (nzchar(input$alpha_facet)) {
+        plot <- plot + facet_wrap(
+            stats::as.formula(paste("~", input$alpha_facet)),
+            scales = "free_x"
+        )
+    }
+    plot
 })
+
+output$plotAlphaDiversity <- renderPlot(alpha_diversity_plot())
+output$plotOrdination <- renderPlot(ordination_plot())
+output$plotBar <- renderPlot(composition_plot())
+
+register_publication_downloads(
+    output, "download_alpha_diversity",
+    function() "dada2-alpha-diversity",
+    alpha_diversity_plot, width = 8.5, height = 5.5
+)
+register_publication_downloads(
+    output, "download_ordination",
+    function() "dada2-bray-curtis-nmds",
+    ordination_plot, width = 7.5, height = 6.5
+)
+register_publication_downloads(
+    output, "download_composition",
+    function() "dada2-taxonomic-composition",
+    composition_plot, width = 10, height = 6.5
+)
 
 
 # output$plotAlphaDiversity <-  renderPlot({

--- a/dada2Shiny/src/server-errorRates.R
+++ b/dada2Shiny/src/server-errorRates.R
@@ -1,14 +1,23 @@
-output$plotErrors_errF <- renderPlot({
+error_plot_forward <- reactive({
     errF <- reactiveInputData()$errF
-    print("plotErrors_errF")
-    # print(errF)
-
     plotErrors(errF, nominalQ = TRUE)
 })
 
-output$plotErrors_errR <- renderPlot({
+error_plot_reverse <- reactive({
     errR <- reactiveInputData()$errR
-    print("plotErrors_errR")
-
     plotErrors(errR, nominalQ = TRUE)
 })
+
+output$plotErrors_errF <- renderPlot(error_plot_forward())
+output$plotErrors_errR <- renderPlot(error_plot_reverse())
+
+register_publication_downloads(
+    output, "download_error_forward",
+    function() "dada2-forward-error-model",
+    error_plot_forward, width = 8.5, height = 6.5
+)
+register_publication_downloads(
+    output, "download_error_reverse",
+    function() "dada2-reverse-error-model",
+    error_plot_reverse, width = 8.5, height = 6.5
+)

--- a/dada2Shiny/src/server-filter_and_trim.R
+++ b/dada2Shiny/src/server-filter_and_trim.R
@@ -1,269 +1,273 @@
+activate_dada_results <- function(seq_type) {
+    shinyjs::show(selector = "a[data-value=\"errorRatesTab\"]")
+    if (identical(seq_type, "paired")) {
+        shinyjs::show(selector = "a[data-value=\"margePairedReadsTab\"]")
+        js$addStatusIcon("margePairedReadsTab", "done")
+    }
+    shinyjs::show(selector = "a[data-value=\"taxanomyTab\"]")
+    shinyjs::show(selector = "a[data-value=\"trackReadsTab\"]")
+    shinyjs::show(selector = "a[data-value=\"filter_and_trim_tab\"]")
+    js$addStatusIcon("filter_and_trim_tab", "done")
+    js$addStatusIcon("errorRatesTab", "done")
+    js$addStatusIcon("trackReadsTab", "done")
+    js$addStatusIcon("taxanomyTab", "next")
+    qc_done(TRUE)
+}
+
 reactiveInputData <- eventReactive(input$runDADA2, {
+    shinyjs::disable("runDADA2")
+    on.exit(shinyjs::enable("runDADA2"), add = TRUE)
+
+    # Forked DADA2 workers must receive ordinary values, not Shiny reactives.
+    seq_type <- isolate(input$seq_type)
+    trunc_fwd <- as.integer(isolate(input$truncLen_fwd))
+    trunc_rev <- as.integer(isolate(input$truncLen_rev))
+    max_ee_fwd <- as.numeric(isolate(input$maxEE_fwd))
+    max_ee_rev <- as.numeric(isolate(input$maxEE_rev))
+    selected_sample <- isolate(input$sel_sample_qualityprofile_tab)
+    req(selected_sample)
+
     qc_done(FALSE)
     divergen_done(FALSE)
-    
-    # Clear all reactive values from downstream processing to ensure clean state
-    if (exists("reactiveTaxonomyData")) {
-        reactiveTaxonomyData$taxa <- NULL
-    }
-    if (exists("selectedTaxonomyRows")) {
-        selectedTaxonomyRows(NULL)
-    }
+    if (exists("reactiveTaxonomyData")) reactiveTaxonomyData$taxa <- NULL
+    if (exists("selectedTaxonomyRows")) selectedTaxonomyRows(NULL)
     if (exists("alphaDiversityResults")) {
         alphaDiversityResults$ps <- NULL
         alphaDiversityResults$ps.prop <- NULL
         alphaDiversityResults$ord.nmds.bray <- NULL
         alphaDiversityResults$ps.top20 <- NULL
     }
-    
-    #    shinyjs::hide(selector = "a[data-value=\"qualityprofile_tab\"]")
+
     shinyjs::hide(selector = "a[data-value=\"errorRatesTab\"]")
-    # shinyjs::hide(selector = "a[data-value=\"filter_and_trim_tab\"]")
     shinyjs::hide(selector = "a[data-value=\"margePairedReadsTab\"]")
     shinyjs::hide(selector = "a[data-value=\"trackReadsTab\"]")
     shinyjs::hide(selector = "a[data-value=\"taxanomyTab\"]")
     shinyjs::hide(selector = "a[data-value=\"alphaDiversityTab\"]")
-
-
-
-
     js$addStatusIcon("filter_and_trim_tab", "loading")
-    req(input$sel_sample_qualityprofile_tab)
-    path <- my_values$base_dir
-    sample.names <- row.names(my_values$samples_df)
 
-    # print(my_values$samples_df)
-    fnFs <- file.path(path, my_values$samples_df[, "FASTQ_Fs"])
+    input_path <- my_values$base_dir
+    project_path <- my_values$work_dir
+    local_work_path <- my_values$local_work_dir
+    req(input_path, project_path, local_work_path, my_values$samples_df)
 
-    filtFs <- file.path(path, "filtered", paste0(sample.names, "_F_filt.fastq.gz"))
-    print("dir1")
-    sapply(fnFs, function(fasqfile) {
-        print(file.exists(fasqfile))
-    })
-    names(filtFs) <- sample.names
-
-    if (input$seq_type == "paired") {
-        fnRs <- file.path(path, my_values$samples_df[, "FASTQ_Rs"])
-        filtRs <- file.path(path, "filtered", paste0(sample.names, "_R_filt.fastq.gz"))
-        print("dir2")
-        sapply(fnRs, function(fasqfile) {
-            print(file.exists(fasqfile))
-        })
-
-        names(filtRs) <- sample.names
+    sample_names <- row.names(my_values$samples_df)
+    fn_fs <- file.path(input_path, my_values$samples_df[, "FASTQ_Fs"])
+    fn_rs <- character()
+    if (identical(seq_type, "paired")) {
+        fn_rs <- file.path(input_path, my_values$samples_df[, "FASTQ_Rs"])
     }
-    # print(fnFs)
-    # print(fnRs)
 
+    input_paths <- c(fn_fs, fn_rs)
+    input_info <- file.info(input_paths)
+    validate(need(
+        all(file.exists(input_paths)) && all(!input_info$isdir),
+        "One or more FASTQ files are unavailable."
+    ))
 
+    parameters <- list(
+        seq_type = seq_type,
+        trunc_fwd = trunc_fwd,
+        trunc_rev = if (identical(seq_type, "paired")) trunc_rev else NULL,
+        max_ee_fwd = max_ee_fwd,
+        max_ee_rev = if (identical(seq_type, "paired")) max_ee_rev else NULL,
+        dada2_version = as.character(utils::packageVersion("dada2"))
+    )
+    cache_key <- digest::digest(
+        list(
+            paths = normalizePath(input_paths, mustWork = TRUE),
+            sizes = input_info$size,
+            mtimes = as.numeric(input_info$mtime),
+            parameters = parameters
+        ),
+        algo = "xxhash64"
+    )
+    cache_dir <- file.path(project_path, "cache")
+    dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    cache_file <- file.path(cache_dir, paste0(cache_key, ".rds"))
 
+    if (file.exists(cache_file)) {
+        cached_result <- tryCatch(readRDS(cache_file), error = function(e) NULL)
+        if (!is.null(cached_result)) {
+            my_values$cache_status <- paste("Loaded cached DADA2 result:", cache_key)
+            activate_dada_results(seq_type)
+            return(cached_result)
+        }
+    }
 
+    my_values$cache_status <- paste("Computing DADA2 result:", cache_key)
+    filtered_path <- file.path(local_work_path, cache_key, "filtered")
+    dir.create(filtered_path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    filt_fs <- file.path(filtered_path, paste0(sample_names, "_F_filt.fastq.gz"))
+    names(filt_fs) <- sample_names
+    filt_rs <- character()
+    if (identical(seq_type, "paired")) {
+        filt_rs <- file.path(filtered_path, paste0(sample_names, "_R_filt.fastq.gz"))
+        names(filt_rs) <- sample_names
+    }
 
-
-
-    withProgress(message = "Running DADA2 , please wait", {
-        shiny::setProgress(value = 0.1, detail = "...filterAndTrim")
-
-        # disabling multithread as it is runs in reactive context
-        if (input$seq_type == "paired") {
-            out <- filterAndTrim(fnFs, filtFs, fnRs, filtRs,
-                truncLen = c(input$truncLen_fwd, input$truncLen_rev),
-                maxN = 0, maxEE = c(input$maxEE_fwd, input$maxEE_rev), truncQ = 2, rm.phix = TRUE,
-                compress = TRUE, multithread = FALSE
+    withProgress(message = "Running DADA2, please wait", {
+        shiny::setProgress(value = 0.1, detail = "Filtering and trimming")
+        if (identical(seq_type, "paired")) {
+            filtered_counts <- filterAndTrim(
+                fn_fs,
+                filt_fs,
+                fn_rs,
+                filt_rs,
+                truncLen = c(trunc_fwd, trunc_rev),
+                maxN = 0,
+                maxEE = c(max_ee_fwd, max_ee_rev),
+                truncQ = 2,
+                rm.phix = TRUE,
+                compress = TRUE,
+                multithread = hpc_workers
             )
         } else {
-            out <- filterAndTrim(fnFs, filtFs,
-                truncLen = c(input$truncLen_fwd),
-                maxN = 0, maxEE = c(input$maxEE_fwd), truncQ = 2, rm.phix = TRUE,
-                compress = TRUE, multithread = FALSE
+            filtered_counts <- filterAndTrim(
+                fn_fs,
+                filt_fs,
+                truncLen = trunc_fwd,
+                maxN = 0,
+                maxEE = max_ee_fwd,
+                truncQ = 2,
+                rm.phix = TRUE,
+                compress = TRUE,
+                multithread = hpc_workers
+            )
+        }
+        rownames(filtered_counts) <- sample_names
+
+        shiny::setProgress(value = 0.25, detail = "Learning forward-read errors")
+        err_f <- learnErrors(filt_fs, multithread = hpc_workers)
+        err_r <- NULL
+        if (identical(seq_type, "paired")) {
+            shiny::setProgress(value = 0.4, detail = "Learning reverse-read errors")
+            err_r <- learnErrors(filt_rs, multithread = hpc_workers)
+        }
+
+        shiny::setProgress(value = 0.55, detail = "Denoising reads")
+        dada_fs <- dada(filt_fs, err = err_f, multithread = hpc_workers)
+        dada_rs <- NULL
+        mergers <- NULL
+        if (identical(seq_type, "paired")) {
+            dada_rs <- dada(filt_rs, err = err_r, multithread = hpc_workers)
+            shiny::setProgress(value = 0.7, detail = "Merging paired reads")
+            mergers <- mergePairs(
+                dada_fs,
+                filt_fs,
+                dada_rs,
+                filt_rs,
+                verbose = TRUE
+            )
+            updateSelectInput(
+                session,
+                "selSample4margePairedReadsTab",
+                choices = names(mergers)
             )
         }
 
-        rownames(out) <- sample.names
-
-        shiny::setProgress(value = 0.2, detail = "...learnErrors Fr")
-        errF <- learnErrors(filtFs, multithread = TRUE)
-
-        if (input$seq_type == "paired") {
-            shiny::setProgress(value = 0.3, detail = "...learnErrors Rr")
-            errR <- learnErrors(filtRs, multithread = TRUE)
-        }
-
-        shiny::setProgress(value = 0.4, detail = "...dadafs")
-        dadaFs <- dada(filtFs, err = errF, multithread = TRUE)
-
-        if (input$seq_type == "paired") {
-            shiny::setProgress(value = 0.5, detail = "...dadaRs")
-            dadaRs <- dada(filtRs, err = errR, multithread = TRUE)
-        }
-
-        if (input$seq_type == "paired") {
-            shiny::setProgress(value = 0.6, detail = "...mergePairs")
-            mergers <- mergePairs(dadaFs, filtFs, dadaRs, filtRs, verbose = TRUE)
-            # Inspect the merger data.frame from the first sample
-            print("mergers")
-
-
-
-            # print(names(head(mergers)))
-            updateSelectInput(session, "selSample4margePairedReadsTab", choices = names(mergers))
-        }
-        shiny::setProgress(value = 0.7, detail = "...makeSequenceTable")
-
-        if (input$seq_type == "paired") {
-            seqtab <- makeSequenceTable(mergers)
+        shiny::setProgress(value = 0.82, detail = "Removing chimeras")
+        sequence_table <- if (identical(seq_type, "paired")) {
+            makeSequenceTable(mergers)
         } else {
-            seqtab <- makeSequenceTable(dadaFs)
+            makeSequenceTable(dada_fs)
         }
-        dim(seqtab)
+        sequence_lengths <- table(nchar(getSequences(sequence_table)))
+        sequence_table_nochim <- removeBimeraDenovo(
+            sequence_table,
+            method = "consensus",
+            multithread = hpc_workers,
+            verbose = TRUE
+        )
 
-        # Inspect distribution of sequence lengths
-        print("table")
-        seqtabTable <- table(nchar(getSequences(seqtab)))
-
-        shiny::setProgress(value = 0.8, detail = "...makeSequenceTable")
-        # remove chimeras from the sequence table:
-        seqtab.nochim <- removeBimeraDenovo(seqtab, method = "consensus", multithread = TRUE, verbose = TRUE)
-        dim(seqtab.nochim)
-
-        sum(seqtab.nochim) / sum(seqtab)
-
-        getN <- function(x) sum(getUniques(x))
-
-        if (input$seq_type == "paired") {
-
-            denoisedF <- if (inherits(dadaFs, "dada")) getN(dadaFs) else sapply(dadaFs, getN)
-            denoisedR <- if (inherits(dadaRs, "dada")) getN(dadaRs) else sapply(dadaRs, getN)
-            merged <- if (is.data.frame(mergers)) getN(mergers) else sapply(mergers, getN)
-
-            track <- cbind(out, denoisedF, denoisedR, merged, rowSums(seqtab.nochim))
-            # If processing a single sample, remove the sapply calls: e.g. replace sapply(dadaFs, getN) with getN(dadaFs)
-            colnames(track) <- c("input", "filtered", "denoisedF", "denoisedR", "merged", "nonchim")
-            rownames(track) <- sample.names
+        get_n <- function(x) sum(getUniques(x))
+        denoised_f <- if (inherits(dada_fs, "dada")) {
+            get_n(dada_fs)
         } else {
-            denoisedF <- if (inherits(dadaFs, "dada")) getN(dadaFs) else sapply(dadaFs, getN)
-            track <- cbind(out, denoisedF, rowSums(seqtab.nochim))
-            # If processing a single sample, remove the sapply calls: e.g. replace sapply(dadaFs, getN) with getN(dadaFs)
+            vapply(dada_fs, get_n, numeric(1))
+        }
+        if (identical(seq_type, "paired")) {
+            denoised_r <- if (inherits(dada_rs, "dada")) {
+                get_n(dada_rs)
+            } else {
+                vapply(dada_rs, get_n, numeric(1))
+            }
+            merged <- if (is.data.frame(mergers)) {
+                get_n(mergers)
+            } else {
+                vapply(mergers, get_n, numeric(1))
+            }
+            track <- cbind(
+                filtered_counts,
+                denoised_f,
+                denoised_r,
+                merged,
+                rowSums(sequence_table_nochim)
+            )
+            colnames(track) <- c(
+                "input",
+                "filtered",
+                "denoisedF",
+                "denoisedR",
+                "merged",
+                "nonchim"
+            )
+        } else {
+            track <- cbind(
+                filtered_counts,
+                denoised_f,
+                rowSums(sequence_table_nochim)
+            )
             colnames(track) <- c("input", "filtered", "denoisedF", "nonchim")
-            rownames(track) <- sample.names
         }
-        # updateSelectInput(session, "selSample4trackReadsTab", choices = sample.names)
-
-
-        print("track")
-        # print(head(track))
-
-        print("taxa")
-
-
-        # taxa <- assignTaxonomy(seqtab.nochim, "./www/taxonomy/silva_nr99_v138.1_train_set.fa.gz", multithread = TRUE)
-        # print(taxa)
-        # print("taxa second")
-        # taxa <- addSpecies(taxa, "./www/taxonomy/silva_species_assignment_v138.1.fa.gz")
-        # print(taxa)
-        # taxa.print <- taxa # Removing sequence rownames for display only
-        # rownames(taxa.print) <- NULL
-
-
-        # print(head(taxa.print))
-
-
-        # samples.out <- rownames(seqtab.nochim)
-        # print('samples.out')
-        # print(samples.out)
-        # subject <- sapply(strsplit(samples.out, "D"), '[', 1)
-        # gender <- substr(subject,1,1)
-        # subject <- substr(subject,2,999)
-        # # day <- as.integer(sapply(strsplit(samples.out, "D"), '[', 2))
-        # day <- as.integer(sapply(strsplit(sapply(strsplit(samples.out, "D"), '[', 2), '_'), '[', 1))
-        # samdf <- data.frame(Subject=subject, Gender=gender, Day=day)
-        # samdf$When <- "Early"
-        # samdf$When[samdf$Day>100] <- "Late"
-        # rownames(samdf) <- samples.out
-
-        # print("samples.out")
-        # print(samdf)
-
-        # ps <- phyloseq(otu_table(seqtab.nochim, taxa_are_rows=FALSE),
-        #        sample_data(samdf),
-        #        tax_table(taxa))
-        # ps <- prune_samples(sample_names(ps) != "Mock", ps) # Remove mock sample
-
-
-        # dna <- Biostrings::DNAStringSet(taxa_names(ps))
-        # names(dna) <- taxa_names(ps)
-        # ps <- merge_phyloseq(ps, dna)
-        # taxa_names(ps) <- paste0("ASV", seq(ntaxa(ps)))
-        # print(ps)
-        # # Transform data to proportions as appropriate for Bray-Curtis distances
-        # ps.prop <- transform_sample_counts(ps, function(otu) otu/sum(otu))
-        # ord.nmds.bray <- ordinate(ps.prop, method="NMDS", distance="bray")
-
-
-        # top20 <- names(sort(taxa_sums(ps), decreasing=TRUE))[1:20]
-        # ps.top20 <- transform_sample_counts(ps, function(OTU) OTU/sum(OTU))
-        # ps.top20 <- prune_taxa(top20, ps.top20)
-
-        print("qc done")
-
-
-        qc_done(TRUE)
-
-        shiny::setProgress(value = 1.0, detail = "...done")
+        rownames(track) <- sample_names
+        shiny::setProgress(value = 1, detail = "Done")
     })
 
-    shinyjs::show(selector = "a[data-value=\"errorRatesTab\"]")
-    if (input$seq_type == "paired") {
-        shinyjs::show(selector = "a[data-value=\"margePairedReadsTab\"]")
-        js$addStatusIcon("margePairedReadsTab", "done")
+    result <- list(
+        sample.names = sample_names,
+        dadaFs = dada_fs,
+        out = filtered_counts,
+        errF = err_f,
+        seqtabTable = sequence_lengths,
+        track = track,
+        seqtab.nochim = sequence_table_nochim
+    )
+    if (identical(seq_type, "paired")) {
+        result$dadaRs <- dada_rs
+        result$errR <- err_r
+        result$mergers <- mergers
     }
 
-    shinyjs::show(selector = "a[data-value=\"taxanomyTab\"]")
-    shinyjs::show(selector = "a[data-value=\"trackReadsTab\"]")
-    shinyjs::show(selector = "a[data-value=\"filter_and_trim_tab\"]")
-    # shinyjs::show(selector = "a[data-value=\"taxanomyTab\"]")
-
-
-
-    js$addStatusIcon("filter_and_trim_tab", "done")
-    js$addStatusIcon("errorRatesTab", "done")
-    js$addStatusIcon("trackReadsTab", "done")
-    js$addStatusIcon("taxanomyTab", "next")
-    
-
-
-
-
-
-    if (input$seq_type == "paired") {
-        return(list(sample.names=sample.names,dadaFs=dadaFs,dadaRs=dadaRs,mergers=mergers, out = out, errF = errF, errR = errR, mergers = mergers, seqtabTable = seqtabTable, track = track, seqtab.nochim = seqtab.nochim))
-    } else {
-        return(list(sample.names=sample.names,dadaFs=dadaFs,dadaRs=dadaRs, out = out, errF = errF, seqtabTable = seqtabTable, track = track, seqtab.nochim = seqtab.nochim))
-    }
+    saveRDS(result, file.path(project_path, "dada2-results.rds"))
+    write.csv(track, file.path(project_path, "read-tracking.csv"))
+    write.csv(
+        sequence_table_nochim,
+        file.path(project_path, "sequence-table-nochim.csv")
+    )
+    cache_tmp <- paste0(cache_file, ".tmp-", Sys.getpid())
+    saveRDS(result, cache_tmp)
+    if (!file.rename(cache_tmp, cache_file)) unlink(cache_tmp)
+    my_values$cache_status <- paste("Saved DADA2 cache:", cache_key)
+    activate_dada_results(seq_type)
+    result
 })
 
 output$dada2object_ready <- reactive({
-    return(!is.null(reactiveInputData()))
+    !is.null(reactiveInputData())
 })
 outputOptions(output, "dada2object_ready", suspendWhenHidden = FALSE)
 
-
-
-
-
-
 output$filterAndTrim_output_table <- DT::renderDataTable(
     {
-        # print(filtFs)
-
         data <- reactiveInputData()
-
-        # output_table_wth_samples <- cbind(Sample = rownames(data$out), data$out)
-        output_table_wth_samples <- cbind(Sample = data$sample.names, data$out)
-        
-        colnames(output_table_wth_samples) <- c('Sample', "Fragments before Quality trimming", "Fragments after Quality trimming")
-        output_table_wth_samples
+        output_table <- cbind(Sample = data$sample.names, data$out)
+        colnames(output_table) <- c(
+            "Sample",
+            "Fragments before Quality trimming",
+            "Fragments after Quality trimming"
+        )
+        output_table
     },
-    rownames = FALSE, 
+    rownames = FALSE,
     options = list(scrollX = TRUE, pageLength = 10)
 )

--- a/dada2Shiny/src/server-filter_and_trim.R
+++ b/dada2Shiny/src/server-filter_and_trim.R
@@ -257,17 +257,40 @@ output$dada2object_ready <- reactive({
 })
 outputOptions(output, "dada2object_ready", suspendWhenHidden = FALSE)
 
+fragments_summary_table <- reactive({
+    data <- reactiveInputData()
+    req(data)
+    output_table <- data.frame(
+        Sample = data$sample.names,
+        data$out,
+        check.names = FALSE,
+        stringsAsFactors = FALSE
+    )
+    colnames(output_table) <- c(
+        "Sample",
+        "Fragments before quality trimming",
+        "Fragments after quality trimming"
+    )
+    output_table
+})
+
 output$filterAndTrim_output_table <- DT::renderDataTable(
-    {
-        data <- reactiveInputData()
-        output_table <- cbind(Sample = data$sample.names, data$out)
-        colnames(output_table) <- c(
-            "Sample",
-            "Fragments before Quality trimming",
-            "Fragments after Quality trimming"
-        )
-        output_table
-    },
+    fragments_summary_table(),
     rownames = FALSE,
     options = list(scrollX = TRUE, pageLength = 10)
+)
+
+output$download_fragments_summary <- downloadHandler(
+    filename = function() {
+        paste0("dada2-fragments-summary-", Sys.Date(), ".csv")
+    },
+    contentType = "text/csv",
+    content = function(file) {
+        utils::write.csv(
+            fragments_summary_table(),
+            file,
+            row.names = FALSE,
+            na = ""
+        )
+    }
 )

--- a/dada2Shiny/src/server-inputdata.R
+++ b/dada2Shiny/src/server-inputdata.R
@@ -16,6 +16,9 @@ observe({
 my_values <- reactiveValues()
 my_values$mounted_dir <- FALSE
 my_values$downloaded_files <- FALSE
+my_values$work_dir <- NULL
+my_values$local_work_dir <- NULL
+my_values$cache_status <- NULL
 
 # observeEvent(input$connect_remote_server, {
 #     print(input$username)
@@ -132,6 +135,7 @@ outputOptions(output, "qc_result_available", suspendWhenHidden = FALSE)
 # })
 
 input_files_reactive <- eventReactive(input$initFastq, {
+    fn_Rs <- character()
     # shiny::validate(
     #     need(identical(input$data_file_type, "example_bam_file") | (is.null(input$bam_files)),
     #         message = "Please select a file"
@@ -269,6 +273,37 @@ input_files_reactive <- eventReactive(input$initFastq, {
             fn_Fs <- names(matching_files[matching_files == TRUE])
             fn_Rs <- stringr::str_replace_all(fn_Fs, input$forward_pattern, input$reverse_pattern)
         }
+    } else if (identical(input$data_file_type, "hpc_scratch_directory")) {
+        shiny::validate(need(nzchar(trimws(input$hpc_fastq_directory)), "Enter an HPC FASTQ directory."))
+        base_dir <- tryCatch(
+            resolve_hpc_path(input$hpc_fastq_directory),
+            error = function(e) {
+                shiny::validate(need(FALSE, e$message))
+            }
+        )
+        files <- list.files(base_dir, full.names = FALSE)
+        fn_Fs <- files[grepl(input$forward_pattern, files)]
+        if (input$seq_type == "paired") {
+            fn_Rs <- files[grepl(input$reverse_pattern, files)]
+            matching_files <- sapply(fn_Fs, function(fastq_file) {
+                expected <- gsub(
+                    paste0(input$forward_pattern, "$"),
+                    input$reverse_pattern,
+                    fastq_file
+                )
+                expected %in% fn_Rs
+            })
+            fn_Fs <- names(matching_files[matching_files])
+            fn_Rs <- stringr::str_replace_all(
+                fn_Fs,
+                input$forward_pattern,
+                input$reverse_pattern
+            )
+            shiny::validate(need(
+                length(fn_Fs) > 0L && length(fn_Fs) == length(fn_Rs),
+                "No matching paired FASTQ files were found with these patterns."
+            ))
+        }
     } else {
         base_dir <- my_values$download_path
         print(base_dir)
@@ -322,6 +357,21 @@ input_files_reactive <- eventReactive(input$initFastq, {
     }
     my_values$base_dir <- base_dir
     my_values$samples_df <- samples_df
+    my_values$work_dir <- project_directory(
+        if (identical(input$data_file_type, "hpc_scratch_directory")) {
+            input$hpc_project_name
+        } else {
+            paste0("session-", session$token)
+        }
+    )
+    my_values$local_work_dir <- local_working_directory(
+        if (identical(input$data_file_type, "hpc_scratch_directory")) {
+            input$hpc_project_name
+        } else {
+            paste0("session-", session$token)
+        }
+    )
+    my_values$cache_status <- NULL
 
     if(nrow(samples_df) > 0) {
 
@@ -358,7 +408,7 @@ input_files_reactive <- eventReactive(input$initFastq, {
   output$result1 <- renderText({
         # Ensure the input is between 1 and 10
         shiny::validate(
-        need(identical(input$data_file_type, "example_fastq_file") | identical(input$data_file_type, "download_remote_server") | (identical(input$data_file_type, "upload_fastq_file") & !is.null(input$fastq_files) & length(input$fastq_files$name) > 1),
+        need(identical(input$data_file_type, "example_fastq_file") | identical(input$data_file_type, "hpc_scratch_directory") | identical(input$data_file_type, "download_remote_server") | (identical(input$data_file_type, "upload_fastq_file") & !is.null(input$fastq_files) & length(input$fastq_files$name) > 1),
             message = "Please upload both R1 andd R2 fastq files "
         )
     )
@@ -366,12 +416,22 @@ input_files_reactive <- eventReactive(input$initFastq, {
     print('load')
 
     shiny::validate(
-        need(identical(input$data_file_type, "example_fastq_file") | identical(input$data_file_type, "upload_fastq_file") | identical(input$data_file_type, "download_remote_server") & my_values$downloaded_files,
+        need(identical(input$data_file_type, "example_fastq_file") | identical(input$data_file_type, "upload_fastq_file") | identical(input$data_file_type, "hpc_scratch_directory") | identical(input$data_file_type, "download_remote_server") & my_values$downloaded_files,
             message = "Please connect to the server "
         )
     )
         paste("You entered:", input$num)
     })
+
+output$hpc_dada2_path <- renderText({
+    req(my_values$work_dir)
+    paste("DADA2 project output:", my_values$work_dir)
+})
+
+output$dada_cache_status <- renderText({
+    req(my_values$cache_status)
+    my_values$cache_status
+})
 
 
 output$fastqfiles_uploaded <- reactive({

--- a/dada2Shiny/src/server-qualityprofile.R
+++ b/dada2Shiny/src/server-qualityprofile.R
@@ -1,28 +1,25 @@
-output$plot_qualityprofile_fs <- renderPlot({
+quality_profile_forward <- reactive({
     req(input$sel_sample_qualityprofile_tab)
-
-    # print(input$sel_sample_qualityprofile_tab)
-    # print(my_values$samples_df[input$sel_sample_qualityprofile_tab, 'FASTQ_Fs'])
-    print("my_values$samples_df")
-    # print(my_values$samples_df)
-    # print(my_values$base_dir)
     fastq_file <- file.path(my_values$base_dir, my_values$samples_df[input$sel_sample_qualityprofile_tab, "FASTQ_Fs"])
-
     plotQualityProfile(fastq_file)
 })
 
-output$plot_qualityprofile_rs <- renderPlot({
+quality_profile_reverse <- reactive({
     req(input$sel_sample_qualityprofile_tab)
-
-
-    print(input$sel_sample_qualityprofile_tab)
-    # print(my_values$samples_df[input$sel_sample_qualityprofile_tab, 'FASTQ_Rs'])
-
     fastq_file <- file.path(my_values$base_dir, my_values$samples_df[input$sel_sample_qualityprofile_tab, "FASTQ_Rs"])
-    print(fastq_file)
     plotQualityProfile(fastq_file)
 })
 
-text_reactive <- observeEvent(input$submit, {
-    print("submit")
-})
+output$plot_qualityprofile_fs <- renderPlot(quality_profile_forward())
+output$plot_qualityprofile_rs <- renderPlot(quality_profile_reverse())
+
+register_publication_downloads(
+    output, "download_quality_forward",
+    function() paste0("dada2-forward-quality-", input$sel_sample_qualityprofile_tab),
+    quality_profile_forward, width = 8.5, height = 5.5
+)
+register_publication_downloads(
+    output, "download_quality_reverse",
+    function() paste0("dada2-reverse-quality-", input$sel_sample_qualityprofile_tab),
+    quality_profile_reverse, width = 8.5, height = 5.5
+)

--- a/dada2Shiny/src/server-taxonomy.R
+++ b/dada2Shiny/src/server-taxonomy.R
@@ -101,21 +101,42 @@ output$animalculesTransferUI <- renderUI({
             stringsAsFactors = FALSE
         )
 
+        sample_names <- rownames(dada_result$seqtab.nochim)
         metadata <- data.frame(
-            sample = rownames(dada_result$seqtab.nochim),
+            sample = sample_names,
             source = "DADA2Shiny",
+            row.names = sample_names,
             stringsAsFactors = FALSE
         )
-        rownames(metadata) <- metadata$sample
+        if (!is.null(input$sampleData)) {
+            uploaded_metadata <- tryCatch(
+                as.data.frame(qiimeData(), check.names = FALSE),
+                error = function(error) NULL
+            )
+            if (!is.null(uploaded_metadata) &&
+                all(sample_names %in% rownames(uploaded_metadata))) {
+                metadata <- uploaded_metadata[sample_names, , drop = FALSE]
+                metadata$source <- "DADA2Shiny"
+            }
+        }
 
-        exchange_dir <- file.path(tempdir(check = TRUE), "..", "nasqar_exchange")
-        exchange_dir <- normalizePath(exchange_dir, mustWork = FALSE)
-        dir.create(exchange_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+        exchange_dir <- nasqar_exchange_dir(create = TRUE)
         token <- uuid::UUIDgenerate()
+        exchange_path <- file.path(exchange_dir, paste0(token, ".rds"))
+        pending_path <- tempfile(
+            pattern = paste0(token, "-"),
+            tmpdir = exchange_dir,
+            fileext = ".pending"
+        )
         saveRDS(
             list(counts = counts, taxonomy = taxonomy, metadata = metadata),
-            file.path(exchange_dir, paste0(token, ".rds"))
+            pending_path
         )
+        if (!file.rename(pending_path, exchange_path)) {
+            unlink(pending_path)
+            stop("Could not publish the animalcules exchange file.",
+                 call. = FALSE)
+        }
         animalculesExchangeToken(token)
     }
 
@@ -142,120 +163,83 @@ output$animalculesTransferUI <- renderUI({
 # Create a DataTable proxy
 proxy <- dataTableProxy('taxonomyTable')
 
-# Reactive to handle row selection in the taxonomy table and plot generation
-observe({
+# Build the selected-sequence distribution once for both display and export.
+sequence_distribution_plot <- reactive({
     req(reactiveTaxonomyData$taxa)
     req(input$filter_values)
+    req(input$grouping_column)
     selected_rows <- input$taxonomyTable_rows_selected
-
-    # If no rows are selected, select all rows by default
     if (is.null(selected_rows) || length(selected_rows) == 0) {
-        selected_rows <- 1:nrow(reactiveTaxonomyData$taxa)  # Select all rows by default
+        selected_rows <- seq_len(nrow(reactiveTaxonomyData$taxa))
     }
-
-    # Ensure seqtab.nochim is available
     seqtab.nochim <- reactiveInputData()$seqtab.nochim
     req(seqtab.nochim)
-
-    # Get the sequences corresponding to the selected rows
     selected_sequences <- rownames(reactiveTaxonomyData$taxa)[selected_rows]
+    validate(need(length(selected_sequences) > 0, "Select at least one sequence."))
+    validate(need(
+        all(selected_sequences %in% colnames(seqtab.nochim)),
+        "Selected taxonomy rows are not present in the sequence table."
+    ))
 
-    # If no sequences are found in seqtab.nochim, show a message and return
-    if (length(selected_sequences) == 0) {
-        showNotification("No selected sequences found in the dataset.", type = "error")
-        return()
-    }
+    taxonomy <- reactiveTaxonomyData$taxa
+    seq_abundance <- (seqtab.nochim[, selected_sequences, drop = FALSE] > 0) * 1
+    samples_vec <- character()
+    filter_data <- stats::setNames(
+        replicate(length(input$filter_values), numeric(), simplify = FALSE),
+        input$filter_values
+    )
 
-    # Reactive for the selected grouping column
-    grouping_column <- reactive(input$grouping_column)
-
-    if (is.null(grouping_column())) {
-        showNotification("Group not selected.", type = "error")
-        return()
-    }
-
-    # Update the bar plot for the selected sequences
-    output$sequenceDistributionBarChart <- renderPlot({
-        req(input$filter_values)
-        taxonomy <- reactiveTaxonomyData$taxa
-        taxonomy_column_name <- grouping_column()
-
-        # Extract abundance of the selected sequences across samples
-        seq_abundance <- (seqtab.nochim[, selected_sequences, drop = FALSE] > 0) * 1  # Presence/Absence matrix
-
-        # Initialize vectors for each column
-        samples_vec <- c()
-        abundance_vec <- c()
-        filter_data <- list()
-        for (name in input$filter_values) {
-            filter_data[[name]] <- c()
-        }
-
-        # Loop through each row of seq_abundance and add frequency information
-        for (i in 1:nrow(seq_abundance)) {
-            if (sum(seq_abundance[i, ]) > 0){
-                cols_with_one <- which(seq_abundance[i, selected_sequences] == 1)  # Find columns with 1 in the current row
-
-                seq_with_one <- colnames(seq_abundance)[cols_with_one]  # Get column names (sequences) with 1
-
-                selected_column_values <- taxonomy[seq_with_one, input$grouping_column, drop = TRUE]
-                frequency_table <- table(selected_column_values)
-
-                # Add sample and abundance
-                samples_vec <- c(samples_vec, rownames(seq_abundance)[i])
-                abundance_vec <- c(abundance_vec, sum(seq_abundance[i, ]))
-
-                # Add frequency values for each filter
-                for (name in input$filter_values) {
-                    count_value <- if (name %in% names(frequency_table)) {
-                        as.numeric(frequency_table[name])
+    for (i in seq_len(nrow(seq_abundance))) {
+        if (sum(seq_abundance[i, ]) > 0) {
+            seq_with_one <- colnames(seq_abundance)[which(seq_abundance[i, ] == 1)]
+            frequency_table <- table(
+                taxonomy[seq_with_one, input$grouping_column, drop = TRUE]
+            )
+            samples_vec <- c(samples_vec, rownames(seq_abundance)[i])
+            for (name in input$filter_values) {
+                filter_data[[name]] <- c(
+                    filter_data[[name]],
+                    if (name %in% names(frequency_table)) {
+                        as.numeric(frequency_table[[name]])
                     } else {
                         0
                     }
-                    filter_data[[name]] <- c(filter_data[[name]], count_value)
-                }
+                )
             }
         }
+    }
+    validate(need(length(samples_vec) > 0, "No selected sequences occur in any sample."))
 
-        # Check if we have any data
-        if (length(samples_vec) == 0) {
-            # Return an empty plot with a message
-            return(ggplot() + 
-                   annotate("text", x = 0.5, y = 0.5, label = "No data to display", size = 6) +
-                   theme_void())
-        }
+    plot_data <- data.frame(Sample = samples_vec, check.names = FALSE)
+    for (name in input$filter_values) plot_data[[name]] <- filter_data[[name]]
+    plot_data_long <- tidyr::pivot_longer(
+        plot_data,
+        cols = tidyselect::all_of(input$filter_values),
+        names_to = input$grouping_column,
+        values_to = "Value"
+    )
 
-        # Build data frame from vectors
-        plot_data <- data.frame(
-            Sample = samples_vec,
-            Abundance = abundance_vec,
-            stringsAsFactors = FALSE
-        )
-        
-        # Add filter columns
-        for (name in input$filter_values) {
-            plot_data[[name]] <- filter_data[[name]]
-        }
-
-        # Convert the data into a long format for plotting
-        plot_data_long <- tidyr::pivot_longer(
-            plot_data,
-            cols = input$filter_values,
-            names_to = grouping_column(),  # New column to represent grouping
-            values_to = "Value"  # 1 or 0 based on the values
-        )
-
-        # Create the bar plot with grouping
-        ggplot(plot_data_long, aes(x = Sample, y = Value, fill = .data[[grouping_column()]])) +
-            geom_bar(stat = "identity") +
-            labs(title = paste("Distribution of Selected Sequences Across Samples (Grouped by", grouping_column(), ")"),
-                 x = "Sample",
-                 y = "Abundance") +
-            theme_minimal() +
-            theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
-            scale_fill_discrete(name = grouping_column())
-    })
+    ggplot(plot_data_long, aes(
+        x = Sample,
+        y = Value,
+        fill = .data[[input$grouping_column]]
+    )) +
+        geom_col() +
+        labs(
+            x = "Sample",
+            y = "Sequence occurrence",
+            fill = input$grouping_column
+        ) +
+        theme_minimal(base_size = 12) +
+        theme(axis.text.x = element_text(angle = 45, hjust = 1))
 })
+
+output$sequenceDistributionBarChart <- renderPlot(sequence_distribution_plot())
+register_publication_downloads(
+    output, "download_sequence_distribution",
+    function() "dada2-selected-sequence-distribution",
+    sequence_distribution_plot, width = 10, height = 6
+)
 
 # Function to update the grouping column values and filter
 updateGroupingAndFilter <- function(selected_rows, grouping_column) {

--- a/dada2Shiny/src/server-taxonomy.R
+++ b/dada2Shiny/src/server-taxonomy.R
@@ -1,6 +1,7 @@
 # Define reactive values to hold the selected databases and selected taxonomy rows
 reactiveTaxonomyData <- reactiveValues()
 selectedTaxonomyRows <- reactiveVal(NULL)
+animalculesExchangeToken <- reactiveVal(NULL)
 
 # Event to assign taxonomy
 observeEvent(input$assignTaxonomy, {
@@ -30,7 +31,7 @@ observeEvent(input$assignTaxonomy, {
     # Assign taxonomy using the selected reference database
     withProgress(message = "Assigning Taxonomy, please wait...", {
         shiny::setProgress(value = 0.1, detail = "...assigning taxonomy")
-        taxa <- assignTaxonomy(seqtab.nochim, reference_db, multithread = TRUE)
+        taxa <- assignTaxonomy(seqtab.nochim, reference_db, multithread = hpc_workers)
         
         # Assign species if a species-level database is selected
         if (!is.null(species_db)) {
@@ -44,6 +45,14 @@ observeEvent(input$assignTaxonomy, {
     # Store taxonomy and species assignment results
     taxa[is.na(taxa)] <- 'unknown'
     reactiveTaxonomyData$taxa <- taxa
+    if (!is.null(my_values$work_dir)) {
+        taxonomy_output <- cbind(Sequence = rownames(taxa), taxa)
+        write.csv(
+            taxonomy_output,
+            file.path(my_values$work_dir, "taxonomy-table.csv"),
+            row.names = FALSE
+        )
+    }
 
     # Update icons and tabs
     shinyjs::show(selector = "a[data-value=\"alphaDiversityTab\"]")
@@ -68,6 +77,66 @@ output$taxonomyTable <- DT::renderDataTable({
               rownames = FALSE, 
               options = list(scrollX = TRUE, pageLength = 10), 
               selection = 'multiple')  # Specify multiple row selection
+})
+
+output$animalculesTransferUI <- renderUI({
+    req(reactiveTaxonomyData$taxa)
+    dada_result <- reactiveInputData()
+    req(dada_result$seqtab.nochim)
+
+    token <- animalculesExchangeToken()
+    if (is.null(token)) {
+        sequences <- colnames(dada_result$seqtab.nochim)
+        asv_ids <- sprintf("ASV%04d", seq_along(sequences))
+
+        counts <- t(dada_result$seqtab.nochim)
+        rownames(counts) <- asv_ids
+
+        taxonomy <- reactiveTaxonomyData$taxa[sequences, , drop = FALSE]
+        rownames(taxonomy) <- asv_ids
+        taxonomy <- data.frame(
+            Sequence = sequences,
+            taxonomy,
+            check.names = FALSE,
+            stringsAsFactors = FALSE
+        )
+
+        metadata <- data.frame(
+            sample = rownames(dada_result$seqtab.nochim),
+            source = "DADA2Shiny",
+            stringsAsFactors = FALSE
+        )
+        rownames(metadata) <- metadata$sample
+
+        exchange_dir <- file.path(tempdir(check = TRUE), "..", "nasqar_exchange")
+        exchange_dir <- normalizePath(exchange_dir, mustWork = FALSE)
+        dir.create(exchange_dir, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+        token <- uuid::UUIDgenerate()
+        saveRDS(
+            list(counts = counts, taxonomy = taxonomy, metadata = metadata),
+            file.path(exchange_dir, paste0(token, ".rds"))
+        )
+        animalculesExchangeToken(token)
+    }
+
+    handoffPath <- paste0(
+        "/animalcules/?exchange=",
+        URLencode(token, reserved = TRUE)
+    )
+
+    tags$a(
+        icon("external-link-alt"),
+        "Open directly in animalcules",
+        href = handoffPath,
+        `data-handoff-path` = handoffPath,
+        onclick = paste(
+            "this.href = window.location.origin +",
+            "this.getAttribute('data-handoff-path');"
+        ),
+        target = "_blank",
+        class = "btn btn-success",
+        style = "width: 100%; margin-top: 10px;"
+    )
 })
 
 # Create a DataTable proxy

--- a/dada2Shiny/src/server.R
+++ b/dada2Shiny/src/server.R
@@ -1,6 +1,47 @@
 options(shiny.maxRequestSize = 30 * 1024^4)
 
 server <- function(input, output, session) {
+    hpc_workers <- suppressWarnings(as.integer(Sys.getenv("SLURM_CPUS_PER_TASK", "1")))
+    if (is.na(hpc_workers) || hpc_workers < 1L) hpc_workers <- 1L
+
+    resolve_hpc_path <- function(path) {
+        root <- normalizePath(
+            Sys.getenv("NASQAR_DATA_ROOT", unset = "/scratch/nr83"),
+            mustWork = TRUE
+        )
+        resolved <- normalizePath(path, mustWork = TRUE)
+        allowed <- identical(resolved, root) ||
+            startsWith(resolved, paste0(root, .Platform$file.sep))
+        if (!allowed) stop("The directory must be inside the configured HPC data root.")
+        if (!dir.exists(resolved)) stop("The HPC FASTQ path must be a directory.")
+        resolved
+    }
+
+    project_directory <- function(name) {
+        root <- Sys.getenv("NASQAR_DADA2_PROJECT_DIR", unset = "")
+        if (!nzchar(root)) return(file.path(tempdir(), "dada2-project"))
+        safe_name <- gsub("[^A-Za-z0-9._-]+", "-", trimws(name))
+        if (!nzchar(safe_name)) safe_name <- "dada2-project"
+        path <- file.path(root, safe_name)
+        dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+        if (!dir.exists(path) || file.access(path, 2) != 0) {
+            stop("The DADA2 HPC project directory is not writable.")
+        }
+        path
+    }
+
+    local_working_directory <- function(name) {
+        root <- Sys.getenv("NASQAR_DADA2_WORK_DIR", unset = tempdir())
+        safe_name <- gsub("[^A-Za-z0-9._-]+", "-", trimws(name))
+        if (!nzchar(safe_name)) safe_name <- paste0("session-", session$token)
+        path <- file.path(root, safe_name)
+        dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+        if (!dir.exists(path) || file.access(path, 2) != 0) {
+            stop("The DADA2 node-local work directory is not writable.")
+        }
+        path
+    }
+
     observe({
         # Ping the server every 10 seconds to keep the connection alive
         invalidateLater(10000, session)

--- a/dada2Shiny/src/server.R
+++ b/dada2Shiny/src/server.R
@@ -47,6 +47,7 @@ server <- function(input, output, session) {
         invalidateLater(10000, session)
         input$keepAlive
     })
+    source("analysis-helpers.R", local = TRUE)
     source("server-inputdata.R", local = TRUE)
     source("server-qualityprofile.R", local = TRUE)
     source("server-filter_and_trim.R", local = TRUE)

--- a/dada2Shiny/src/test_analysis_helpers.R
+++ b/dada2Shiny/src/test_analysis_helpers.R
@@ -1,0 +1,27 @@
+source("analysis-helpers.R")
+
+metadata <- data.frame(
+    condition = c("control", "treated"),
+    row.names = c("sample_b", "sample_a")
+)
+aligned <- align_sample_metadata(metadata, c("sample_a", "sample_b"))
+stopifnot(
+    identical(rownames(aligned), c("sample_a", "sample_b")),
+    identical(as.character(aligned$condition), c("treated", "control"))
+)
+
+failed <- FALSE
+tryCatch(
+    align_sample_metadata(metadata, c("sample_a", "missing")),
+    error = function(error) failed <<- TRUE
+)
+stopifnot(failed)
+
+abundance <- c(asv_a = 3, asv_b = 10, asv_c = 5)
+stopifnot(identical(
+    top_taxa_names(abundance, 2L),
+    c("asv_b", "asv_c")
+))
+stopifnot(dir.exists(nasqar_exchange_dir(create = TRUE)))
+
+cat("DADA2 analysis helper tests passed\n")

--- a/dada2Shiny/src/ui-tab-alphaDiversity.R
+++ b/dada2Shiny/src/ui-tab-alphaDiversity.R
@@ -10,21 +10,49 @@ tabItem(
                 fileInput("sampleData", "Choose QIIME Metadata File",
                     accept = c(".csv", ".tsv", ".txt")
                 ),
-                actionButton("runAlphaDiversity", "Run AlphaDiversity", class = "btn-info btn-success", style = "width: 100%")
+                uiOutput("alphaDiversityMappings"),
+                actionButton(
+                    "runAlphaDiversity",
+                    "Run diversity analysis",
+                    class = "btn-info btn-success",
+                    style = "width: 100%"
+                )
             ),
         ),
         column(
             12,
             conditionalPanel(
                 condition = "output.divergen_available",
-                withSpinner(plotOutput("plotAlphaDiversity"))
+                box(
+                    title = "Alpha diversity",
+                    width = 12,
+                    solidHeader = TRUE,
+                    status = "primary",
+                    withSpinner(plotOutput("plotAlphaDiversity", height = "420px")),
+                    tags$p(
+                        class = "text-muted",
+                        "Within-sample Shannon and Simpson diversity grouped by the selected metadata variables."
+                    ),
+                    publication_downloads("download_alpha_diversity")
+                )
             )
         ),
         column(
             12,
             conditionalPanel(
                 condition = "output.divergen_available",
-                withSpinner(plotOutput("plotOrdination"))
+                box(
+                    title = "Bray-Curtis ordination",
+                    width = 12,
+                    solidHeader = TRUE,
+                    status = "primary",
+                    withSpinner(plotOutput("plotOrdination", height = "520px")),
+                    tags$p(
+                        class = "text-muted",
+                        "NMDS representation of between-sample Bray-Curtis dissimilarity."
+                    ),
+                    publication_downloads("download_ordination")
+                )
             )
             # withSpinner(plotOutput("plotOrdination"))
         ),
@@ -32,7 +60,18 @@ tabItem(
             12,
             conditionalPanel(
                 condition = "output.divergen_available",
-                withSpinner(plotOutput("plotBar"))
+                box(
+                    title = "Taxonomic composition",
+                    width = 12,
+                    solidHeader = TRUE,
+                    status = "primary",
+                    withSpinner(plotOutput("plotBar", height = "520px")),
+                    tags$p(
+                        class = "text-muted",
+                        "Relative abundance of the 20 most abundant ASVs at the selected taxonomy rank."
+                    ),
+                    publication_downloads("download_composition")
+                )
             )
             #     withSpinner(plotOutput("plotBar"))
         )

--- a/dada2Shiny/src/ui-tab-errorRates.R
+++ b/dada2Shiny/src/ui-tab-errorRates.R
@@ -15,7 +15,9 @@ tabItem(
             ),
             column(
                 6,
-                withSpinner(plotOutput("plotErrors_errF"))
+                h4("Forward-read error model"),
+                withSpinner(plotOutput("plotErrors_errF", height = "520px")),
+                publication_downloads("download_error_forward")
 
             
             ),
@@ -23,7 +25,9 @@ tabItem(
                 6,
                 conditionalPanel(
                     "input.seq_type == 'paired'",
-                    withSpinner(plotOutput("plotErrors_errR"))
+                    h4("Reverse-read error model"),
+                    withSpinner(plotOutput("plotErrors_errR", height = "520px")),
+                    publication_downloads("download_error_reverse")
                 )
 
             )

--- a/dada2Shiny/src/ui-tab-filter_and_trim.R
+++ b/dada2Shiny/src/ui-tab-filter_and_trim.R
@@ -64,7 +64,16 @@ tabItem(
             conditionalPanel(condition = "output.dada2object_ready === true",
             box(
                 title = "Fragments Summary Table", solidHeader = TRUE, status = "primary", width = 12, collapsible = TRUE, collapsed = FALSE,
-                withSpinner(dataTableOutput("filterAndTrim_output_table"))
+                withSpinner(dataTableOutput("filterAndTrim_output_table")),
+                tags$div(
+                    style = "margin-top: 12px; text-align: right;",
+                    downloadButton(
+                        "download_fragments_summary",
+                        "Download summary (CSV)",
+                        icon = icon("download"),
+                        class = "btn btn-primary"
+                    )
+                )
             ))
         )
     )

--- a/dada2Shiny/src/ui-tab-filter_and_trim.R
+++ b/dada2Shiny/src/ui-tab-filter_and_trim.R
@@ -52,7 +52,8 @@ tabItem(
                     )
                 ),
     
-                actionButton("runDADA2", "Run DADA2", class = "btn-info btn-success", style = "width: 100%")
+                actionButton("runDADA2", "Run DADA2", class = "btn-info btn-success", style = "width: 100%"),
+                textOutput("dada_cache_status")
             )
         )
     ),

--- a/dada2Shiny/src/ui-tab-inputdata.R
+++ b/dada2Shiny/src/ui-tab-inputdata.R
@@ -7,13 +7,24 @@ tabItem(
                 title = "Upload fastq file", solidHeader = T, status = "primary", width = 12, collapsible = T, id = "uploadbox",
                 # h4("Upload Gene Counts"),
     
-                radioButtons("data_file_type", "Use example file or upload your own data (zipped or unzipped FASTQ files)",
+                radioButtons("data_file_type", "Select FASTQ data source",
                     c(
                         "Upload fastq File" = "upload_fastq_file",
                         "Example fastq file" = "example_fastq_file",
-                        "Download from remote server" = "download_remote_server"
+                        "Download from remote server" = "download_remote_server",
+                        "Use HPC scratch directory" = "hpc_scratch_directory"
                     ),
                     selected = "example_fastq_file"
+                ),
+                conditionalPanel(
+                    condition = "input.data_file_type=='hpc_scratch_directory'",
+                    textInput(
+                        "hpc_fastq_directory",
+                        "FASTQ directory inside HPC scratch",
+                        value = ""
+                    ),
+                    textInput("hpc_project_name", "Persistent project name", value = "dada2-project"),
+                    helpText("Input FASTQ files are read in place. Filtered reads and results are written to the private DADA2 project directory.")
                 ),
                 conditionalPanel(
                     condition = "input.data_file_type=='download_remote_server'",
@@ -40,6 +51,7 @@ tabItem(
                     )
                 ),
                  textOutput("status"),
+                    textOutput("hpc_dada2_path"),
                     tags$style("#status { color: red; }")
             ),
             box(

--- a/dada2Shiny/src/ui-tab-qualityprofile.R
+++ b/dada2Shiny/src/ui-tab-qualityprofile.R
@@ -9,7 +9,7 @@ tabItem(
 
                     column(6,
                        
-                        selectInput("sel_sample_qualityprofile_tab", "Salect Sample", choices = NULL, selected = NULL)
+                        selectInput("sel_sample_qualityprofile_tab", "Select Sample", choices = NULL, selected = NULL)
                       
                     ),
                     column(12,
@@ -19,11 +19,15 @@ tabItem(
                     ),
                     column(12,
                         column(6,
-                            withSpinner(plotOutput("plot_qualityprofile_fs"))
+                            h4("Forward-read quality profile"),
+                            withSpinner(plotOutput("plot_qualityprofile_fs", height = "440px")),
+                            publication_downloads("download_quality_forward")
                         ),
                         column(6,
                             conditionalPanel("input.seq_type == 'paired'",
-                                withSpinner(plotOutput("plot_qualityprofile_rs"))
+                                h4("Reverse-read quality profile"),
+                                withSpinner(plotOutput("plot_qualityprofile_rs", height = "440px")),
+                                publication_downloads("download_quality_reverse")
                         ))
                     )
                 )

--- a/dada2Shiny/src/ui-tab-taxonomy.R
+++ b/dada2Shiny/src/ui-tab-taxonomy.R
@@ -16,7 +16,7 @@ tabItem(
           12,
           p("Assigning taxonomy is an important step, especially in 16S/18S/ITS amplicon sequencing, to classify sequence variants.
           The DADA2 package uses a robust classifier method for this purpose."),
-          p("It takes as input a set of sequences and a training set of reference sequences with known taxonomy. You can choose from pre-formatted training sets such as RDP, GreenGenes, Silva, or upload your own custom database.")
+          p("It takes a set of sequences and a training set with known taxonomy. This deployment provides SILVA v138.1 and also accepts a custom DADA2-formatted reference database.")
         ),
 
         # Section 1: Reference Database Selection
@@ -33,7 +33,7 @@ tabItem(
             6,
             radioButtons("database_choice", "Select Reference Database:",
               choices = list(
-                "SILVA v132 (Default)" = "silva",
+                "SILVA v138.1 (Default)" = "silva",
                 "Upload Custom" = "custom"
               ),
               selected = "silva"
@@ -154,7 +154,12 @@ tabItem(
           width = 12,
           collapsible = TRUE,
           collapsed = FALSE,
-          withSpinner(plotOutput("sequenceDistributionBarChart"))
+          withSpinner(plotOutput("sequenceDistributionBarChart", height = "520px")),
+          tags$p(
+            class = "text-muted",
+            "Occurrence of the selected sequence variants across samples, grouped by the chosen taxonomy rank."
+          ),
+          publication_downloads("download_sequence_distribution")
         )
       )
     )

--- a/dada2Shiny/src/ui.R
+++ b/dada2Shiny/src/ui.R
@@ -11,6 +11,15 @@ library(ggplot2)
 library(httr)
 library(rmarkdown)
 
+publication_downloads <- function(id) {
+    tags$div(
+        class = "publication-downloads",
+        tags$span(class = "publication-downloads__label", "Download figure"),
+        downloadButton(paste0(id, "_png"), "PNG (300 DPI)", class = "btn btn-default btn-sm"),
+        downloadButton(paste0(id, "_pdf"), "PDF", class = "btn btn-default btn-sm"),
+        downloadButton(paste0(id, "_svg"), "SVG", class = "btn btn-default btn-sm")
+    )
+}
 
 # library(future)
 # library(promises)
@@ -54,6 +63,19 @@ ui <- dashboardPage(
             max-width: 100%; /* Adjust the width of selectize input */
             overflow: hidden; 
             text-overflow: ellipsis; /* This will truncate long text */
+        }
+        .publication-downloads {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 8px;
+            padding: 10px 0 4px;
+            border-top: 1px solid #d9dee3;
+        }
+        .publication-downloads__label {
+            color: #4f5b66;
+            font-weight: 600;
+            margin-right: 4px;
         }
         ")),
 

--- a/deseq2shiny/src/core-functions.R
+++ b/deseq2shiny/src/core-functions.R
@@ -132,39 +132,42 @@ safe_file_name <- function(value, extension = NULL) {
   value
 }
 
+nasqar_exchange_dir <- function(create = FALSE) {
+  configured <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
+  path <- if (nzchar(configured)) {
+    configured
+  } else {
+    file.path(dirname(tempdir(check = TRUE)), "nasqar_exchange")
+  }
+  if (create) {
+    dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+  }
+  normalizePath(path, mustWork = create)
+}
+
+new_exchange_file <- function(extension = ".csv") {
+  file.path(
+    nasqar_exchange_dir(create = TRUE),
+    paste0(uuid::UUIDgenerate(), extension)
+  )
+}
+
 validate_exchange_path <- function(path) {
   if (!is.character(path) || length(path) != 1L || !nzchar(path)) {
     stop("Invalid NASQAR exchange path.", call. = FALSE)
   }
 
   resolved <- normalizePath(path, mustWork = TRUE)
-  configured_root <- Sys.getenv("NASQAR_EXCHANGE_DIR", unset = "")
-
-  if (nzchar(configured_root)) {
-    allowed_root <- normalizePath(configured_root, mustWork = TRUE)
-    prefix <- paste0(allowed_root, .Platform$file.sep)
-    if (!startsWith(resolved, prefix)) {
-      stop("Exchange file is outside the configured NASQAR directory.",
-           call. = FALSE)
-    }
-  } else {
-    # Backward-compatible constraint for GeneCountMerger handoffs.
-    temp_parent <- normalizePath(dirname(tempdir()), mustWork = TRUE)
-    temp_prefix <- paste0(temp_parent, .Platform$file.sep)
-    if (!startsWith(resolved, temp_prefix)) {
-      stop("Exchange file is outside the temporary NASQAR directory.",
-           call. = FALSE)
-    }
-    relative_path <- substring(resolved, nchar(temp_parent) + 2L)
-    path_parts <- strsplit(relative_path, .Platform$file.sep, fixed = TRUE)[[1L]]
-    uuid_csv <- "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.csv$"
-
-    if (length(path_parts) != 2L ||
-        !grepl("^Rtmp[A-Za-z0-9]+$", path_parts[[1L]]) ||
-        !grepl(uuid_csv, path_parts[[2L]])) {
-      stop("Exchange path does not match a NASQAR temporary CSV.",
-           call. = FALSE)
-    }
+  allowed_root <- nasqar_exchange_dir(create = TRUE)
+  prefix <- paste0(allowed_root, .Platform$file.sep)
+  uuid_csv <- paste0(
+    "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-",
+    "[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.csv$"
+  )
+  if (!startsWith(resolved, prefix) ||
+      !grepl(uuid_csv, basename(resolved))) {
+    stop("Exchange path does not match a NASQAR2 exchange CSV.",
+         call. = FALSE)
   }
 
   info <- file.info(resolved)
@@ -172,6 +175,87 @@ validate_exchange_path <- function(path) {
     stop("Exchange file is invalid or too large.", call. = FALSE)
   }
   resolved
+}
+
+publication_downloads <- function(id) {
+    shiny::tags$div(
+        class = "publication-downloads",
+        shiny::tags$span(class = "publication-downloads__label", "Download figure"),
+        shiny::downloadButton(
+            paste0(id, "_png"), "PNG (300 DPI)",
+            class = "btn btn-default btn-sm"
+        ),
+        shiny::downloadButton(
+            paste0(id, "_pdf"), "PDF",
+            class = "btn btn-default btn-sm"
+        ),
+        shiny::downloadButton(
+            paste0(id, "_svg"), "SVG",
+            class = "btn btn-default btn-sm"
+        )
+    )
+}
+
+draw_publication_plot <- function(plot_function) {
+    plot_object <- plot_function()
+    if (inherits(plot_object, c("gg", "ggplot", "grob", "gTree", "gtable"))) {
+        print(plot_object)
+    }
+    invisible(plot_object)
+}
+
+register_publication_downloads <- function(
+    output,
+    id,
+    filename,
+    plot_function,
+    width = 8,
+    height = 6
+) {
+    formats <- list(
+        png = list(
+            extension = "png",
+            content_type = "image/png",
+            open = function(file) {
+                grDevices::png(
+                    file,
+                    width = width,
+                    height = height,
+                    units = "in",
+                    res = 300,
+                    type = if (capabilities("cairo")) "cairo" else getOption("bitmapType")
+                )
+            }
+        ),
+        pdf = list(
+            extension = "pdf",
+            content_type = "application/pdf",
+            open = function(file) {
+                grDevices::pdf(file, width = width, height = height, useDingbats = FALSE)
+            }
+        ),
+        svg = list(
+            extension = "svg",
+            content_type = "image/svg+xml",
+            open = function(file) grDevices::svg(file, width = width, height = height)
+        )
+    )
+    for (format in names(formats)) {
+        config <- formats[[format]]
+        local({
+            local_format <- format
+            local_config <- config
+            output[[paste0(id, "_", local_format)]] <- shiny::downloadHandler(
+                filename = function() paste0(filename(), ".", local_config$extension),
+                contentType = local_config$content_type,
+                content = function(file) {
+                    local_config$open(file)
+                    on.exit(grDevices::dev.off(), add = TRUE)
+                    draw_publication_plot(plot_function)
+                }
+            )
+        })
+    }
 }
 
 snapshot_saved_results <- function(file_list) {

--- a/deseq2shiny/src/server-analysisRes.R
+++ b/deseq2shiny/src/server-analysisRes.R
@@ -195,8 +195,7 @@ output$factorsStr <- renderText({
 
 
 output$analysisRes_enrichGo <- renderUI({
-    fileUrl <- UUIDgenerate()
-    fileUrl <- file.path(session_dir, paste0(fileUrl, ".csv"))
+    fileUrl <- new_exchange_file(".csv")
     csv <- myValues$vsResults
 
     write.csv(csv, file = fileUrl)
@@ -204,13 +203,13 @@ output$analysisRes_enrichGo <- renderUI({
         class = "BoxArea3", 
         style = "text-align: center; padding: 10px;",
         p(strong("Enrichment Analysis")),
-        a("ClusterProfShinyORA (goEnrich)", 
-          href = paste0("/ClusterProfShinyORA?countsdata=", encryptUrlParam(fileUrl)), 
+        a("ClusterProfShinyORA (ORA)",
+          href = paste0("/ClusterProfShinyORA/?countsdata=", encryptUrlParam(fileUrl)),
           class = "btn btn-success btn-block", 
           target = "_blank", 
           style = "margin-bottom: 10px;"),
-        a("ClusterProfShinyGSEA (GSEA)", 
-          href = paste0("/ClusterProfShinyGSEA?countsdata=", encryptUrlParam(fileUrl)), 
+        a("ClusterProfShinyGSEA (GSEA)",
+          href = paste0("/ClusterProfShinyGSEA/?countsdata=", encryptUrlParam(fileUrl)),
           class = "btn btn-success btn-block", 
           target = "_blank")
     ))

--- a/deseq2shiny/src/server-runDeseq.R
+++ b/deseq2shiny/src/server-runDeseq.R
@@ -258,6 +258,47 @@ output$rlogData <- renderDataTable(
     options = list(scrollX = TRUE, pageLength = 5)
 )
 
+transformed_distance_plot <- function(matrix) {
+    validate(need(!is.null(matrix), "Run DESeq2 before exporting this figure."))
+    sample_distances <- stats::dist(t(matrix))
+    sample_matrix <- as.matrix(sample_distances)
+    colors <- grDevices::colorRampPalette(
+        rev(RColorBrewer::brewer.pal(9, "Blues"))
+    )(255)
+    pheatmap::pheatmap(
+        sample_matrix,
+        clustering_distance_rows = sample_distances,
+        clustering_distance_cols = sample_distances,
+        color = colors,
+        border_color = NA,
+        main = "Sample distance heatmap"
+    )
+}
+
+transformed_pca_plot <- function(transformed, intgroup) {
+    validate(need(!is.null(transformed), "Run DESeq2 before exporting this figure."))
+    if (is.null(intgroup) || !nzchar(intgroup)) {
+        intgroup <- names(SummarizedExperiment::colData(transformed))[1]
+    }
+    pca_data <- DESeq2::plotPCA(
+        transformed,
+        intgroup = intgroup,
+        returnData = TRUE
+    )
+    percent_var <- attr(pca_data, "percentVar")
+    ggplot2::ggplot(
+        pca_data,
+        ggplot2::aes(x = PC1, y = PC2, color = group, label = name)
+    ) +
+        ggplot2::geom_point(size = 3.5, alpha = 0.9) +
+        ggplot2::labs(
+            x = sprintf("PC1: %.1f%% variance", percent_var[1] * 100),
+            y = sprintf("PC2: %.1f%% variance", percent_var[2] * 100),
+            color = intgroup
+        ) +
+        ggplot2::theme_classic(base_size = 12)
+}
+
 output$rlogPlot <- renderPlotly({
     if (!is.null(myValues$rlogMat)) {
         sampleDists <- dist(t(myValues$rlogMat))
@@ -479,6 +520,31 @@ output$vsdPcaPlot <- renderPlotly({
         return(p)
     }
 })
+
+register_publication_downloads(
+    output, "download_vst_distance",
+    function() "deseq2-vst-sample-distance",
+    function() transformed_distance_plot(myValues$vstMat),
+    width = 8, height = 7
+)
+register_publication_downloads(
+    output, "download_vst_pca",
+    function() "deseq2-vst-pca",
+    function() transformed_pca_plot(myValues$vsd, input$vsdIntGroupsInput),
+    width = 8, height = 6
+)
+register_publication_downloads(
+    output, "download_rlog_distance",
+    function() "deseq2-rlog-sample-distance",
+    function() transformed_distance_plot(myValues$rlogMat),
+    width = 8, height = 7
+)
+register_publication_downloads(
+    output, "download_rlog_pca",
+    function() "deseq2-rlog-pca",
+    function() transformed_pca_plot(myValues$rld, input$rlogIntGroupsInput),
+    width = 8, height = 6
+)
 
 output$vsdData <- renderDataTable(
     {

--- a/deseq2shiny/src/server-svaseq.R
+++ b/deseq2shiny/src/server-svaseq.R
@@ -101,30 +101,21 @@ output$svaText <- renderText({
     return(paste("Using biological factors:", input$designFormulaSva, "to estimate Surrogate Variables (SVs)"))
 })
 
-output$svaPlot <- renderPlotly({
+sva_scatter_plot <- reactive({
     dds <- svaReactive()$ddsSva
-
-    if (!is.null(dds)) {
-        df <- as.data.frame(colData(dds))
-
-        xaxis <- input$xaxisSva
-        yaxis <- input$yaxisSva
-        colorBy <- input$colorBy
-
-        if (xaxis == "" && yaxis == "" && colorBy == "") {
-            xaxis <- colnames(df)[1]
-            yaxis <- colnames(df)[1]
-            colorBy <- colnames(df)[1]
-        }
-
-        ggplot(df, aes_string(xaxis, yaxis, col = colorBy)) +
-            geom_point(size = 4, alpha = 0.9) +
-            geom_text(aes(label = rownames(df)), hjust = 0, vjust = 0,
-                      size = 4) +
-            theme_minimal(base_size = 15)
+    req(dds)
+    df <- as.data.frame(colData(dds))
+    axes <- c(input$xaxisSva, input$yaxisSva, input$colorBy)
+    if (any(!nzchar(axes))) {
+        axes[!nzchar(axes)] <- colnames(df)[1]
     }
+    ggplot(df, aes_string(axes[1], axes[2], col = axes[3])) +
+        geom_point(size = 3.5, alpha = 0.9) +
+        geom_text(aes(label = rownames(df)), hjust = 0, vjust = 0, size = 3.5) +
+        theme_minimal(base_size = 12)
 })
 
+output$svaPlot <- renderPlotly(ggplotly(sva_scatter_plot()))
 
 observeEvent(input$regressVarsBatch, ignoreInit = TRUE, {
     withProgress(message = "Removing batch effect, this may take a long time.", {
@@ -157,25 +148,37 @@ observeEvent(input$regressVarsBatch, ignoreInit = TRUE, {
 })
 
 
-output$pcaSvaPlot <- renderPlotly({
+pca_sva_plot <- reactive({
     validate(need(length(input$factorNameInputSva) > 0, "Need at least one condition!"))
-
     vsd <- myValues$vsdSva
-
-    if (!is.null(vsd)) {
-        p <- DESeq2::plotPCA(vsd, intgroup = input$factorNameInputSva)
-        if (length(p$layers) > 0) {
-            p$layers[[1]]$aes_params$size <- 4
-            p$layers[[1]]$aes_params$alpha <- 0.9
-        }
-        ggplotly(p + theme_minimal(base_size = 15)) %>%
-            layout(
-                font = list(size = 15),
-                margin = list(l = 90, r = 40, b = 80, t = 60)
-            ) %>%
-            config(responsive = TRUE, displaylogo = FALSE)
+    req(vsd)
+    p <- DESeq2::plotPCA(vsd, intgroup = input$factorNameInputSva)
+    if (length(p$layers) > 0) {
+        p$layers[[1]]$aes_params$size <- 4
+        p$layers[[1]]$aes_params$alpha <- 0.9
     }
+    p + theme_minimal(base_size = 12)
 })
+
+output$pcaSvaPlot <- renderPlotly({
+    ggplotly(pca_sva_plot()) %>%
+        layout(
+            font = list(size = 15),
+            margin = list(l = 90, r = 40, b = 80, t = 60)
+        ) %>%
+        config(responsive = TRUE, displaylogo = FALSE)
+})
+
+register_publication_downloads(
+    output, "download_sva_scatter",
+    function() "deseq2-surrogate-variable-scatter",
+    sva_scatter_plot, width = 8, height = 6
+)
+register_publication_downloads(
+    output, "download_sva_pca",
+    function() "deseq2-batch-corrected-pca",
+    pca_sva_plot, width = 8, height = 6
+)
 
 output$pcaSvaAvailable <- reactive({
     return(!is.null(myValues$vsdSva))

--- a/deseq2shiny/src/server.R
+++ b/deseq2shiny/src/server.R
@@ -301,6 +301,61 @@ stateExportServer <- function(id, root_input, root_output, root_session) {
     )
     dir.create(session_dir, recursive = TRUE, showWarnings = FALSE)
 
+    hpc_state_dir <- Sys.getenv("NASQAR_DESEQ2_STATE_DIR", unset = "")
+    hpc_state_enabled <- nzchar(hpc_state_dir) &&
+        dir.exists(hpc_state_dir) &&
+        file.access(hpc_state_dir, 2) == 0
+
+    list_hpc_states <- function() {
+        if (!hpc_state_enabled) {
+            return(character())
+        }
+        files <- list.files(
+            hpc_state_dir,
+            pattern = "\\.[Rr][Dd]ata$",
+            full.names = FALSE
+        )
+        files[order(
+            file.info(file.path(hpc_state_dir, files))$mtime,
+            decreasing = TRUE
+        )]
+    }
+
+    refresh_hpc_states <- function(selected = NULL) {
+        states <- list_hpc_states()
+        choices <- if (length(states) > 0) {
+            stats::setNames(states, states)
+        } else {
+            c("No saved states" = "")
+        }
+        updateSelectInput(
+            session,
+            "hpcStateFile",
+            choices = choices,
+            selected = if (is.null(selected)) choices[[1]] else selected
+        )
+    }
+
+    hpc_state_path <- function(filename) {
+        if (is.null(filename)) {
+            filename <- ""
+        }
+        filename <- trimws(filename)
+        if (!nzchar(filename)) {
+            stop("Enter a state filename.")
+        }
+        if (!grepl("\\.[Rr][Dd]ata$", filename)) {
+            filename <- paste0(filename, ".RData")
+        }
+        if (
+            !identical(filename, basename(filename)) ||
+            !grepl("^[A-Za-z0-9][A-Za-z0-9._-]*\\.[Rr][Dd]ata$", filename)
+        ) {
+            stop("Use only letters, numbers, periods, underscores, and hyphens.")
+        }
+        file.path(hpc_state_dir, filename)
+    }
+
     # Add error handling for client-side communication issues
     session$onFlushed(function() {
         # This runs after the session is flushed to the client
@@ -1375,113 +1430,137 @@ stateExportServer <- function(id, root_input, root_output, root_session) {
         )
     }
     
+    save_state_file <- function(file) {
+        withProgress(message = "Saving application state...", value = 0, {
+            setProgress(value = 0.1, detail = "Collecting core data...")
+            setProgress(value = 0.3, detail = "Collecting DESeq2 objects...")
+            setProgress(value = 0.5, detail = "Collecting analysis results...")
+            setProgress(value = 0.7, detail = "Collecting UI inputs...")
+            setProgress(value = 0.8, detail = "Creating state object...")
+            state_object <- saveAppState()
+            setProgress(value = 0.9, detail = "Writing state file...")
+            save(state_object, file = file)
+            setProgress(value = 1.0, detail = "State saved successfully!")
+        })
+    }
+
+    load_state_file <- function(state_file) {
+        withProgress(message = "Loading application state...", value = 0, {
+            setProgress(value = 0.1, detail = "Reading state file...")
+            state_size <- file.info(state_file)$size
+            if (is.na(state_size) || state_size > 100 * 1024^2) {
+                stop("State file exceeds the 100 MB safety limit.")
+            }
+            state_environment <- new.env(parent = emptyenv())
+            loaded_names <- load(state_file, envir = state_environment)
+
+            setProgress(value = 0.2, detail = "Validating state file...")
+            if (
+                !identical(loaded_names, "state_object") ||
+                !exists(
+                    "state_object",
+                    envir = state_environment,
+                    inherits = FALSE
+                )
+            ) {
+                stop("Invalid state file: 'state_object' not found.")
+            }
+            state_object <- get(
+                "state_object",
+                envir = state_environment,
+                inherits = FALSE
+            )
+            if (!is.list(state_object)) {
+                stop("Invalid state file: state_object must be a list.")
+            }
+            state_object <- validate_state_object(state_object)
+
+            setProgress(value = 0.4, detail = "Restoring application state...")
+            success <- loadAppState(state_object)
+            if (!isTRUE(success)) {
+                stop("State loaded with errors. Please check the saved data.")
+            }
+
+            setProgress(value = 0.7, detail = "Restoring UI inputs...")
+            setProgress(value = 0.85, detail = "Preparing interface...")
+            setProgress(value = 0.95, detail = "Finalizing restoration...")
+            if (!is.null(myValues$vsResults)) {
+                updateTabItems(session, "tabs", "resultsTab")
+            } else if (!is.null(myValues$dds)) {
+                updateTabItems(session, "tabs", "deseqTab")
+            } else if (!is.null(myValues$DF)) {
+                updateTabItems(session, "tabs", "conditionsTab")
+            } else {
+                updateTabItems(session, "tabs", "inputdata")
+            }
+            setProgress(value = 1.0, detail = "State loaded successfully!")
+        })
+        showNotification(
+            "Application state loaded successfully!",
+            type = "message",
+            duration = 3
+        )
+        removeModal()
+    }
+
     # Save state handler
     output$downloadState <- downloadHandler(
         filename = function() {
             paste0("deseq2shiny_state_", format(Sys.time(), "%Y%m%d_%H%M%S"), ".RData")
         },
         content = function(file) {
-            withProgress(message = "Saving application state...", value = 0, {
-                # Step 1: Collecting core data
-                setProgress(value = 0.1, detail = "Collecting core data...")
-                
-                # Step 2: Collecting DESeq2 objects
-                setProgress(value = 0.3, detail = "Collecting DESeq2 objects...")
-                
-                # Step 3: Collecting analysis results
-                setProgress(value = 0.5, detail = "Collecting analysis results...")
-                
-                # Step 4: Collecting UI inputs
-                setProgress(value = 0.7, detail = "Collecting UI inputs...")
-                
-                # Step 5: Creating state object
-                setProgress(value = 0.8, detail = "Creating state object...")
-                state_object <- saveAppState()
-                
-                # Step 6: Writing to file
-                setProgress(value = 0.9, detail = "Writing state file...")
-                save(state_object, file = file)
-                
-                # Step 7: Complete
-                setProgress(value = 1.0, detail = "State saved successfully!")
-            })
-            
+            save_state_file(file)
             showNotification("Application state saved successfully!", type = "default", duration = 3)
         }
     )
+
+    observeEvent(input$saveStateToHpc, {
+        req(hpc_state_enabled)
+        tryCatch({
+            state_file <- hpc_state_path(input$hpcStateName)
+            if (file.exists(state_file)) {
+                stop("A state with this filename already exists.")
+            }
+            save_state_file(state_file)
+            refresh_hpc_states(basename(state_file))
+            showNotification(
+                paste("State saved to HPC scratch as", basename(state_file)),
+                type = "message",
+                duration = 5
+            )
+        }, error = function(error) {
+            showNotification(error$message, type = "error", duration = 6)
+        })
+    })
     
     # Load state handler
     observeEvent(input$loadStateFile, {
         req(input$loadStateFile)
-        
-        withProgress(message = "Loading application state...", value = 0, {
-            tryCatch({
-                # Step 1: Reading state file
-                setProgress(value = 0.1, detail = "Reading state file...")
-                state_file <- input$loadStateFile$datapath
-                state_size <- file.info(state_file)$size
-                if (is.na(state_size) || state_size > 100 * 1024^2) {
-                    stop("State file exceeds the 100 MB safety limit.")
-                }
-                state_environment <- new.env(parent = emptyenv())
-                loaded_names <- load(state_file, envir = state_environment)
-                
-                # Step 2: Validating state object
-                setProgress(value = 0.2, detail = "Validating state file...")
-                if (!identical(loaded_names, "state_object") ||
-                    !exists("state_object", envir = state_environment, inherits = FALSE)) {
-                    showNotification("Invalid state file: 'state_object' not found", type = "error", duration = 5)
-                    return()
-                }
-                state_object <- get(
-                    "state_object",
-                    envir = state_environment,
-                    inherits = FALSE
-                )
-                if (!is.list(state_object)) {
-                    stop("Invalid state file: state_object must be a list.")
-                }
-                state_object <- validate_state_object(state_object)
-                
-                # Step 3: Load all components using the comprehensive loadAppState function
-                setProgress(value = 0.4, detail = "Restoring application state...")
-                success <- loadAppState(state_object)
-                
-                if (success) {
-                    # Step 4: Restoring UI inputs
-                    setProgress(value = 0.7, detail = "Restoring UI inputs...")
-                    
-                    # Step 5: Determining navigation
-                    setProgress(value = 0.85, detail = "Preparing interface...")
-                    
-                    # Step 6: Navigate to appropriate tab
-                    setProgress(value = 0.95, detail = "Finalizing restoration...")
-                    if (!is.null(myValues$vsResults)) {
-                        updateTabItems(session, "tabs", "resultsTab")
-                    } else if (!is.null(myValues$dds)) {
-                        updateTabItems(session, "tabs", "deseqTab")
-                    } else if (!is.null(myValues$DF)) {
-                        updateTabItems(session, "tabs", "conditionsTab")
-                    } else {
-                        updateTabItems(session, "tabs", "inputdata")
-                    }
-                    
-                    # Step 7: Complete
-                    setProgress(value = 1.0, detail = "State loaded successfully!")
-                    showNotification("Application state loaded successfully!", type = "message", duration = 3)
-                    
-                    # Close the modal
-                    removeModal()
-                } else {
-                    showNotification("State loaded with some errors. Please check your data.", type = "warning", duration = 5)
-                }
-                
-            }, error = function(e) {
-                showNotification(
-                    paste("Error loading state file:", e$message),
-                    type = "error", duration = 5
-                )
-            })
+        tryCatch({
+            load_state_file(input$loadStateFile$datapath)
+        }, error = function(error) {
+            showNotification(
+                paste("Error loading state file:", error$message),
+                type = "error",
+                duration = 5
+            )
+        })
+    })
+
+    observeEvent(input$loadStateFromHpc, {
+        req(hpc_state_enabled, input$hpcStateFile)
+        tryCatch({
+            state_file <- hpc_state_path(input$hpcStateFile)
+            if (!file.exists(state_file)) {
+                stop("The selected HPC state file no longer exists.")
+            }
+            load_state_file(state_file)
+        }, error = function(error) {
+            showNotification(
+                paste("Error loading HPC state:", error$message),
+                type = "error",
+                duration = 6
+            )
         })
     })
     
@@ -2505,6 +2584,9 @@ stateExportServer <- function(id, root_input, root_output, root_session) {
     # Observer for showing state modal using Shiny's native modal (better nginx support)
     observeEvent(input$showStateModal, {
         canSave <- !is.null(myValues$dataCounts) || !is.null(myValues$dds)
+        if (hpc_state_enabled) {
+            refresh_hpc_states()
+        }
         
         # Check which plots are available (only show buttons when plots are actually configured/visible)
         hasVolcano <- !is.null(input$select_avo_de_file) && 
@@ -2553,7 +2635,30 @@ stateExportServer <- function(id, root_input, root_output, root_session) {
                             downloadButton("downloadState", 
                                          "💾 Download State File (.RData)", 
                                          class = "btn btn-success", 
-                                         style = "width: 100%; font-weight: bold; font-size: 14px; padding: 10px; border-radius: 6px; box-shadow: 0 2px 6px rgba(40,167,69,0.3);")
+                                         style = "width: 100%; font-weight: bold; font-size: 14px; padding: 10px; border-radius: 6px; box-shadow: 0 2px 6px rgba(40,167,69,0.3);"),
+                            if (hpc_state_enabled) {
+                                tagList(
+                                    hr(),
+                                    h5(icon("server"), " HPC Scratch"),
+                                    textInput(
+                                        "hpcStateName",
+                                        "State filename",
+                                        value = paste0(
+                                            "deseq2shiny_state_",
+                                            format(Sys.time(), "%Y%m%d_%H%M%S"),
+                                            ".RData"
+                                        ),
+                                        width = "100%"
+                                    ),
+                                    actionButton(
+                                        "saveStateToHpc",
+                                        "Save State to HPC Scratch",
+                                        icon = icon("save"),
+                                        class = "btn-primary",
+                                        style = "width: 100%;"
+                                    )
+                                )
+                            }
                         )
                     } else {
                         div(style = "background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 8px; padding: 15px; margin-bottom: 20px;",
@@ -2583,7 +2688,33 @@ stateExportServer <- function(id, root_input, root_output, root_session) {
                         ),
                         div(style = "margin-top: 10px; padding: 10px; background-color: #e7f3ff; border-left: 3px solid #0066cc; border-radius: 4px; font-size: 11px; color: #004085;",
                             icon("info-circle"), " Loads all data, results, and plot settings from saved session"
-                        )
+                        ),
+                        if (hpc_state_enabled) {
+                            tagList(
+                                hr(),
+                                h5(icon("server"), " HPC Scratch"),
+                                selectInput(
+                                    "hpcStateFile",
+                                    "Saved state",
+                                    choices = {
+                                        states <- list_hpc_states()
+                                        if (length(states) > 0) {
+                                            stats::setNames(states, states)
+                                        } else {
+                                            c("No saved states" = "")
+                                        }
+                                    },
+                                    width = "100%"
+                                ),
+                                actionButton(
+                                    "loadStateFromHpc",
+                                    "Load State from HPC Scratch",
+                                    icon = icon("folder-open"),
+                                    class = "btn-primary",
+                                    style = "width: 100%;"
+                                )
+                            )
+                        }
                     )
                 ),
                 column(6,

--- a/deseq2shiny/src/test_state_management.R
+++ b/deseq2shiny/src/test_state_management.R
@@ -59,12 +59,18 @@ stopifnot(
 )
 
 exchange_filename <- "550e8400-e29b-41d4-a716-446655440000.csv"
-exchange_path <- file.path(tempdir(), exchange_filename)
+exchange_path <- file.path(
+  nasqar_exchange_dir(create = TRUE),
+  exchange_filename
+)
 write.csv(data.frame(gene = "g1", count = 1L), exchange_path,
           row.names = FALSE)
 stopifnot(identical(validate_exchange_path(exchange_path),
                     normalizePath(exchange_path)))
 expect_error(validate_exchange_path("/etc/passwd"))
+outside_exchange <- file.path(tempdir(), exchange_filename)
+write.csv(data.frame(gene = "g1"), outside_exchange, row.names = FALSE)
+expect_error(validate_exchange_path(outside_exchange))
 
 source_result <- file.path(tempdir(), "source-result.csv")
 write.csv(

--- a/deseq2shiny/src/ui-tab-heatmap.R
+++ b/deseq2shiny/src/ui-tab-heatmap.R
@@ -47,16 +47,19 @@ tabItem(
                         2,
                         actionButton("genHeatmap", "Generate Plot", class = "btn btn-primary", style = "width:100%;")
                     ),
-                    # column(2,
-                    #     offset = 10,
-                    #     conditionalPanel(
-                    #         "output.heatmapComputed",
-                    #         downloadButton("downloadHighResHeatmap",
-                    #             "Download Heatmap",
-                    #             class = "btn btn-warning"
-                    #         )
-                    #     )
-                    # ),
+                    column(
+                        2,
+                        offset = 10,
+                        conditionalPanel(
+                            "output.heatmapComputed",
+                            downloadButton(
+                                "downloadHighResHeatmap",
+                                "Download Heatmap (PDF)",
+                                class = "btn btn-warning",
+                                style = "width:100%;"
+                            )
+                        )
+                    ),
                     column(
                         12,
                         p("* This heatmap uses normalized counts which can be viewed/downloaded below the figure")

--- a/deseq2shiny/src/ui-tab-rlog.R
+++ b/deseq2shiny/src/ui-tab-rlog.R
@@ -9,12 +9,14 @@ tabItem(
             wellPanel(
                 box(
                     title = "Distance Heatmap", width = 12, solidHeader = T, status = "primary",
-                    withSpinner(plotlyOutput(outputId = "rlogPlot", height = "650px"))
+                    withSpinner(plotlyOutput(outputId = "rlogPlot", height = "650px")),
+                    publication_downloads("download_rlog_distance")
                 ),
                 box(
                     title = "PCA Plot", width = 12, solidHeader = T, status = "primary",
                     selectInput("rlogIntGroupsInput", "Group of interest", choices = c()),
-                    withSpinner(plotlyOutput(outputId = "rlogPcaPlot", height = "650px"))
+                    withSpinner(plotlyOutput(outputId = "rlogPcaPlot", height = "650px")),
+                    publication_downloads("download_rlog_pca")
                 ),
                 h4(p(class = "text-right", downloadButton("downloadRlogCsv", "Download rlog.csv", class = "btn btn-primary btn-sm"))),
                 withSpinner(dataTableOutput("rlogData"))

--- a/deseq2shiny/src/ui-tab-svaseq.R
+++ b/deseq2shiny/src/ui-tab-svaseq.R
@@ -41,7 +41,8 @@ tabItem(
                     title = "SVA Plot", width = 12, solidHeader = T, status = "primary",
                     column(
                         8,
-                        withSpinner(plotlyOutput("svaPlot"))
+                        withSpinner(plotlyOutput("svaPlot")),
+                        publication_downloads("download_sva_scatter")
                     ),
                     column(
                         4,
@@ -104,7 +105,8 @@ tabItem(
                             h4(strong("PCA (VST) after regression of batch/surrogate variable(s)")),
                             column(
                                 8,
-                                withSpinner(plotlyOutput("pcaSvaPlot"))
+                                withSpinner(plotlyOutput("pcaSvaPlot")),
+                                publication_downloads("download_sva_pca")
                             ),
                             column(
                                 4,

--- a/deseq2shiny/src/ui-tab-vst.R
+++ b/deseq2shiny/src/ui-tab-vst.R
@@ -10,12 +10,14 @@ tabItem(
             wellPanel(
                 box(
                     title = "Distance Heatmap", width = 12, solidHeader = T, status = "primary", height = "100%",
-                    withSpinner(plotlyOutput(outputId = "vsdPlot", height = "800px"))
+                    withSpinner(plotlyOutput(outputId = "vsdPlot", height = "800px")),
+                    publication_downloads("download_vst_distance")
                 ),
                 box(
                     title = "PCA Plot", width = 12, solidHeader = T, status = "primary",
                     selectInput("vsdIntGroupsInput", "Group of interest", choices = c()),
-                    withSpinner(plotlyOutput(outputId = "vsdPcaPlot", height = "800px"))
+                    withSpinner(plotlyOutput(outputId = "vsdPcaPlot", height = "800px")),
+                    publication_downloads("download_vst_pca")
                 ),
                 h4(p(class = "text-right", downloadButton("downloadVsdCsv", "Download vsd.csv", class = "btn btn-primary btn-sm"))),
                 withSpinner(dataTableOutput("vsdData"))

--- a/deseq2shiny/src/www/custom.css
+++ b/deseq2shiny/src/www/custom.css
@@ -473,3 +473,18 @@ div[style*="overflow-y: auto"]::-webkit-scrollbar-thumb:hover {
         transform: scale(1);
     }
 }
+.publication-downloads {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px 0 4px;
+    margin-top: 10px;
+    border-top: 1px solid #d9dee3;
+}
+
+.publication-downloads__label {
+    color: #4f5b66;
+    font-weight: 600;
+    margin-right: 4px;
+}

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,6 +12,7 @@ dependencies:
 - r-base==4.3.3
 - r-biocmanager
 - r-car
+- r-cairo
 - r-clustree
 - r-colourpicker
 - r-devtools
@@ -81,6 +82,9 @@ dependencies:
 - bioconductor-limmagui
 - bioconductor-motifdb
 - bioconductor-multiassayexperiment
+- bioconductor-org.dm.eg.db
+- bioconductor-org.hs.eg.db
+- bioconductor-org.mm.eg.db
 - bioconductor-pathview
 - bioconductor-phyloseq
 - bioconductor-rhdf5
@@ -90,6 +94,7 @@ dependencies:
 - bioconductor-summarizedexperiment
 - bioconductor-sva
 - bioconductor-tximport
+- bioconductor-txdb.hsapiens.ucsc.hg19.knowngene
 - binutils
 - biom-format
 - bpp-core

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -1,0 +1,113 @@
+# NASQAR2 on Jubail HPC
+
+This package runs the all-in-one NASQAR2 image as an unprivileged Singularity
+container inside a Slurm compute allocation.
+
+## Build the image
+
+The local definition imports the current `nasqar2-local:bulk-gcm` Docker image:
+
+```bash
+./hpc/build-sif.sh
+```
+
+The default output is `hpc/build/nasqar2.sif`.
+Building requires approximately 25 GB of temporary space. If `/tmp` is too
+small, direct the temporary files and cache to a larger filesystem:
+
+```bash
+mkdir -p /data/nasqar2-build/{tmp,cache}
+TMPDIR=/data/nasqar2-build/tmp \
+SINGULARITY_TMPDIR=/data/nasqar2-build/tmp \
+SINGULARITY_CACHEDIR=/data/nasqar2-build/cache \
+./hpc/build-sif.sh /data/nasqar2-build/nasqar2.sif
+```
+
+## Copy to Jubail
+
+```bash
+ssh nr83@jubail.abudhabi.nyu.edu \
+  'mkdir -p "$SCRATCH/nasqar2"/{images,runs,slurm}'
+rsync -ah --partial hpc/build/nasqar2.sif \
+  nr83@jubail.abudhabi.nyu.edu:/scratch/nr83/nasqar2/images/nasqar2.sif
+rsync -ah hpc/slurm/nasqar2.sbatch \
+  nr83@jubail.abudhabi.nyu.edu:/scratch/nr83/nasqar2/slurm/
+```
+
+## Submit
+
+```bash
+ssh nr83@jubail.abudhabi.nyu.edu \
+  'cd "$SCRATCH/nasqar2/slurm" && sbatch nasqar2.sbatch'
+```
+
+The job output reports the allocated compute node, selected port, SSH tunnel
+command, and browser URL. The port defaults to a job-specific value between
+20000 and 39999.
+
+```bash
+ssh nr83@jubail.abudhabi.nyu.edu \
+  'cat "$SCRATCH/nasqar2/runs/<job-id>/connection.txt"'
+```
+
+## Runtime data
+
+The Slurm script binds this writable directory to `/runtime`:
+
+```text
+/scratch/nr83/nasqar2/runs/<job-id>/
+```
+
+It contains application logs, Nginx state, caches, temporary uploads,
+cross-module exchange files, results, and `connection.txt`. The `.sif` remains
+read-only.
+
+The Slurm job also exposes `$SCRATCH` inside the container as a read-only data
+root. In ATACseqQC, select **Use HPC scratch directory** and enter a directory
+such as `/scratch/nr83/project/bams` to load matching BAM/BAI pairs without a
+browser upload. Override the allowed root at submission time when needed:
+
+```bash
+NASQAR2_DATA_ROOT=/scratch/nr83/project sbatch nasqar2.sbatch
+```
+
+Runtime R packages are installed into the private, writable library
+`$SCRATCH/nasqar2/r-library/R-4.3`. The library persists across jobs while the
+SIF and input data remain read-only. Override it when a separate package
+environment is required:
+
+```bash
+NASQAR2_R_LIBRARY=/scratch/nr83/project/r-library sbatch nasqar2.sbatch
+```
+
+## Resource defaults
+
+The supplied job requests one task, 16 CPU cores, 32 GB RAM, and eight
+hours. Adjust these values to the intended dataset. Do not start NASQAR2 on a
+Jubail login node.
+
+ATACseqQC caches chromosome-specific core, nucleosome, and footprint results
+under `$SCRATCH/nasqar2/cache/ATACseqQC`. Cached results are keyed by the BAM
+path, size, modification time, genome, chromosome, and motif. The application
+uses up to three Slurm CPUs concurrently for PT, NFR, and TSSE scoring.
+
+DESeq2Shiny can also save and restore its existing `.RData` application states
+directly in `$SCRATCH/nasqar2/states/DESeq2Shiny`. The private directory
+persists across Slurm jobs while browser download and upload remain available.
+
+DADA2, Seurat v5, and Monocle 3 can read datasets directly from the read-only
+HPC data root. Their generated files persist across jobs under
+`$SCRATCH/nasqar2/projects/DADA2`, `$SCRATCH/nasqar2/projects/SeuratV5`, and
+`$SCRATCH/nasqar2/projects/Monocle3`. They derive worker counts from
+`SLURM_CPUS_PER_TASK`.
+
+DADA2 performs filtering and trimming in node-local temporary storage. Final
+results and parameter-aware caches persist in its project directory. Cache keys
+include FASTQ paths, sizes, modification times, analysis parameters, and the
+DADA2 package version.
+
+## Open OnDemand
+
+Jubail also provides Open OnDemand at
+<https://ood.hpc.abudhabi.nyu.edu>. The Slurm launcher is the foundation for a
+future NASQAR2 interactive-app form.

--- a/hpc/bin/nasqar2-hpc
+++ b/hpc/bin/nasqar2-hpc
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: nasqar2-hpc [--port PORT] [--runtime DIR] [--allow-login-node]
+
+Starts the NASQAR2 portal and all Shiny services without requiring root.
+Run it inside a Slurm allocation on Jubail.
+EOF
+}
+
+port="${NASQAR_PORT:-}"
+runtime_dir="${NASQAR_RUNTIME_DIR:-/runtime}"
+allow_login="${NASQAR_ALLOW_LOGIN_NODE:-0}"
+
+while (($#)); do
+    case "$1" in
+        --port)
+            port="${2:?--port requires a value}"
+            shift 2
+            ;;
+        --runtime)
+            runtime_dir="${2:?--runtime requires a value}"
+            shift 2
+            ;;
+        --allow-login-node)
+            allow_login=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "${SLURM_JOB_ID:-}" && "$allow_login" != "1" ]]; then
+    echo "NASQAR2 must run inside a Slurm compute job on Jubail." >&2
+    echo "Use --allow-login-node only for a short local smoke test." >&2
+    exit 1
+fi
+
+if [[ -z "$port" ]]; then
+    if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+        port=$((20000 + SLURM_JOB_ID % 20000))
+    else
+        port=8787
+    fi
+fi
+
+if ! [[ "$port" =~ ^[0-9]+$ ]] || ((port < 1024 || port > 65535)); then
+    echo "Port must be an integer between 1024 and 65535." >&2
+    exit 2
+fi
+
+umask 077
+mkdir -p \
+    "$runtime_dir"/cache \
+    "$runtime_dir"/home \
+    "$runtime_dir"/logs \
+    "$runtime_dir"/nginx/client_body \
+    "$runtime_dir"/nginx/fastcgi \
+    "$runtime_dir"/nginx/proxy \
+    "$runtime_dir"/nginx/scgi \
+    "$runtime_dir"/nginx/uwsgi \
+    "$runtime_dir"/R/library \
+    "$runtime_dir"/projects/DADA2 \
+    "$runtime_dir"/projects/SeuratV5 \
+    "$runtime_dir"/projects/Monocle3 \
+    "$runtime_dir"/results \
+    "$runtime_dir"/states/DESeq2Shiny \
+    "$runtime_dir"/tmp
+
+export HOME="$runtime_dir/home"
+export TMPDIR="$runtime_dir/tmp"
+export TMP="$TMPDIR"
+export TEMP="$TMPDIR"
+export XDG_CACHE_HOME="$runtime_dir/cache"
+export R_USER_CACHE_DIR="$runtime_dir/cache/R"
+export R_LIBS_USER="${R_LIBS_USER:-$runtime_dir/R/library}"
+export NASQAR_ATAC_CACHE_DIR="${NASQAR_ATAC_CACHE_DIR:-$runtime_dir/cache/ATACseqQC}"
+export NASQAR_DESEQ2_STATE_DIR="${NASQAR_DESEQ2_STATE_DIR:-$runtime_dir/states/DESeq2Shiny}"
+export NASQAR_DADA2_PROJECT_DIR="${NASQAR_DADA2_PROJECT_DIR:-$runtime_dir/projects/DADA2}"
+export NASQAR_DADA2_WORK_DIR="${NASQAR_DADA2_WORK_DIR:-$runtime_dir/node-tmp/DADA2}"
+export NASQAR_SEURAT_PROJECT_DIR="${NASQAR_SEURAT_PROJECT_DIR:-$runtime_dir/projects/SeuratV5}"
+export NASQAR_MONOCLE3_PROJECT_DIR="${NASQAR_MONOCLE3_PROJECT_DIR:-$runtime_dir/projects/Monocle3}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-${SLURM_CPUS_PER_TASK:-1}}"
+export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-${SLURM_CPUS_PER_TASK:-1}}"
+export MKL_NUM_THREADS="${MKL_NUM_THREADS:-${SLURM_CPUS_PER_TASK:-1}}"
+export RCPP_PARALLEL_NUM_THREADS="${RCPP_PARALLEL_NUM_THREADS:-${SLURM_CPUS_PER_TASK:-1}}"
+export PATH="/opt/conda/envs/merged_env/bin:$PATH"
+
+nginx_conf="$runtime_dir/nginx/nginx.conf"
+{
+    printf 'pid %s;\n' "$runtime_dir/nginx/nginx.pid"
+    printf 'error_log %s;\n' "$runtime_dir/logs/nginx-error.log"
+    sed \
+        -e '/^[[:space:]]*user[[:space:]].*;[[:space:]]*$/d' \
+        -e 's|include[[:space:]]\+mime\.types;|include /etc/nginx/mime.types;|' \
+        -e "s/listen[[:space:]]\\+80;/listen 0.0.0.0:$port;/" \
+        -e "/^[[:space:]]*http[[:space:]]*{/a\\
+        access_log $runtime_dir/logs/nginx-access.log;\\
+        client_body_temp_path $runtime_dir/nginx/client_body;\\
+        fastcgi_temp_path $runtime_dir/nginx/fastcgi;\\
+        proxy_temp_path $runtime_dir/nginx/proxy;\\
+        scgi_temp_path $runtime_dir/nginx/scgi;\\
+        uwsgi_temp_path $runtime_dir/nginx/uwsgi;" \
+        /etc/nginx/nginx.conf
+} > "$nginx_conf"
+
+r_bin="/opt/conda/envs/merged_env/bin/R"
+if [[ ! -x "$r_bin" ]]; then
+    echo "R executable not found: $r_bin" >&2
+    exit 1
+fi
+
+declare -a child_pids=()
+declare -a service_names=()
+declare -a service_ports=()
+
+cleanup() {
+    local status=$?
+    trap - EXIT INT TERM
+    for pid in "${child_pids[@]:-}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+start_shiny() {
+    local name="$1"
+    local service_port="$2"
+    local app_path="$3"
+
+    "$r_bin" --vanilla --slave -e \
+        "shiny::runApp('$app_path', port=$service_port, host='127.0.0.1', launch.browser=FALSE)" \
+        >"$runtime_dir/logs/$name.log" 2>&1 &
+
+    child_pids+=("$!")
+    service_names+=("$name")
+    service_ports+=("$service_port")
+}
+
+start_shiny deseq2shiny 4001 /srv/shiny-server/deseq2shiny/src
+start_shiny ATACseqQCShniy 4002 /srv/shiny-server/ATACseqQCShniy/src
+start_shiny ClusterProfShinyGSEA 4003 /srv/shiny-server/ClusterProfShinyGSEA/src
+start_shiny ClusterProfShinyORA 4004 /srv/shiny-server/ClusterProfShinyORA/src
+start_shiny GeneCountMerger 4005 /srv/shiny-server/GeneCountMerger/src
+start_shiny SeuratV5Shiny 4006 /srv/shiny-server/SeuratV5Shiny/src
+start_shiny animalcules 4007 /srv/shiny-server/animalcules/src
+start_shiny dada2Shiny 4008 /srv/shiny-server/dada2Shiny/src
+start_shiny monocle3 4009 /srv/shiny-server/monocle3/src
+start_shiny DEBrowser 4010 /srv/shiny-server/DEBrowser/src/R
+start_shiny mergeFPKMs 4011 /srv/shiny-server/mergeFPKMs/src
+start_shiny tsar_nasqar 4012 /srv/shiny-server/tsar_nasqar/src
+
+wait_for_port() {
+    local name="$1"
+    local service_port="$2"
+    local service_pid="$3"
+    local deadline=$((SECONDS + 300))
+
+    while ((SECONDS < deadline)); do
+        if ! kill -0 "$service_pid" 2>/dev/null; then
+            echo "$name exited during startup." >&2
+            echo "See $runtime_dir/logs/$name.log" >&2
+            return 1
+        fi
+        if (exec 3<>"/dev/tcp/127.0.0.1/$service_port") 2>/dev/null; then
+            exec 3>&-
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for $name on port $service_port." >&2
+    echo "See $runtime_dir/logs/$name.log" >&2
+    return 1
+}
+
+for index in "${!service_names[@]}"; do
+    wait_for_port \
+        "${service_names[$index]}" \
+        "${service_ports[$index]}" \
+        "${child_pids[$index]}"
+done
+
+/usr/sbin/nginx -t -c "$nginx_conf"
+/usr/sbin/nginx -c "$nginx_conf" -g "daemon off;" \
+    >"$runtime_dir/logs/nginx-stdout.log" 2>&1 &
+nginx_pid=$!
+child_pids+=("$nginx_pid")
+
+node_name="$(hostname -f 2>/dev/null || hostname)"
+cat >"$runtime_dir/connection.txt" <<EOF
+NASQAR2 node: $node_name
+NASQAR2 port: $port
+Tunnel from your workstation:
+ssh -N -L ${port}:${node_name}:${port} nr83@jubail.abudhabi.nyu.edu
+Then open: http://localhost:${port}
+EOF
+
+cat "$runtime_dir/connection.txt"
+echo "Runtime directory: $runtime_dir"
+
+while kill -0 "$nginx_pid" 2>/dev/null; do
+    for index in "${!service_names[@]}"; do
+        if ! kill -0 "${child_pids[$index]}" 2>/dev/null; then
+            echo "${service_names[$index]} stopped unexpectedly." >&2
+            echo "See $runtime_dir/logs/${service_names[$index]}.log" >&2
+            exit 1
+        fi
+    done
+    sleep 5
+done
+
+echo "Nginx stopped unexpectedly. See $runtime_dir/logs/nginx-error.log" >&2
+exit 1

--- a/hpc/build-sif.sh
+++ b/hpc/build-sif.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+output="${1:-$repo_root/hpc/build/nasqar2.sif}"
+definition="$repo_root/hpc/singularity/nasqar2-local.def"
+
+mkdir -p "$(dirname "$output")"
+
+cd "$repo_root"
+singularity build --fakeroot --no-setgroups --force "$output" "$definition"
+
+echo "Built: $output"
+singularity inspect "$output"

--- a/hpc/singularity/nasqar2-local.def
+++ b/hpc/singularity/nasqar2-local.def
@@ -1,0 +1,28 @@
+Bootstrap: docker-daemon
+From: nasqar2-local:bulk-gcm
+
+%labels
+    Author NASQAR2 developers
+    Application NASQAR2
+    Deployment Jubail HPC
+    Runtime Singularity
+
+%files
+    hpc/bin/nasqar2-hpc /opt/nasqar2-hpc/bin/nasqar2-hpc
+
+%post
+    chmod 0755 /opt/nasqar2-hpc/bin/nasqar2-hpc
+    chmod -R a+rX /srv/shiny-server /usr/share/nginx/html /etc/nginx
+    mkdir -p /runtime
+
+%environment
+    export PATH=/opt/conda/envs/merged_env/bin:$PATH
+    export TZ=Asia/Dubai
+
+%runscript
+    exec /opt/nasqar2-hpc/bin/nasqar2-hpc "$@"
+
+%test
+    test -x /opt/nasqar2-hpc/bin/nasqar2-hpc
+    test -x /opt/conda/envs/merged_env/bin/R
+    test -x /usr/sbin/nginx

--- a/hpc/slurm/nasqar2.sbatch
+++ b/hpc/slurm/nasqar2.sbatch
@@ -25,6 +25,7 @@ dada2_projects="${NASQAR2_DADA2_PROJECTS:-$SCRATCH/nasqar2/projects/DADA2}"
 seurat_projects="${NASQAR2_SEURAT_PROJECTS:-$SCRATCH/nasqar2/projects/SeuratV5}"
 monocle3_projects="${NASQAR2_MONOCLE3_PROJECTS:-$SCRATCH/nasqar2/projects/Monocle3}"
 node_tmp="${SLURM_TMPDIR:-/tmp/$USER/nasqar2-$SLURM_JOB_ID}"
+exchange_dir="$runtime_dir/exchange"
 
 if [[ ! -f "$sif" ]]; then
     echo "NASQAR2 image not found: $sif" >&2
@@ -40,14 +41,16 @@ if [[ ! -d "$data_root" ]]; then
 fi
 
 mkdir -p "$runtime_dir/R/library" "$r_library" "$atac_cache" "$deseq2_states" \
-    "$dada2_projects" "$seurat_projects" "$monocle3_projects" "$node_tmp/DADA2"
+    "$dada2_projects" "$seurat_projects" "$monocle3_projects" \
+    "$node_tmp/DADA2" "$exchange_dir"
 chmod 700 "$r_library" "$atac_cache" "$deseq2_states" \
-    "$dada2_projects" "$seurat_projects" "$monocle3_projects"
+    "$dada2_projects" "$seurat_projects" "$monocle3_projects" "$exchange_dir"
 
 singularity exec --cleanenv \
     --env "SLURM_JOB_ID=$SLURM_JOB_ID" \
     --env "SLURM_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK" \
     --env "NASQAR_DATA_ROOT=$data_root" \
+    --env "NASQAR_EXCHANGE_DIR=/runtime/exchange" \
     --env "NASQAR_ATAC_CACHE_DIR=/runtime/cache/ATACseqQC" \
     --env "NASQAR_DESEQ2_STATE_DIR=/runtime/states/DESeq2Shiny" \
     --env "NASQAR_DADA2_PROJECT_DIR=/runtime/projects/DADA2" \

--- a/hpc/slurm/nasqar2.sbatch
+++ b/hpc/slurm/nasqar2.sbatch
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+#SBATCH --job-name=nasqar2
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=32G
+#SBATCH --time=08:00:00
+#SBATCH --output=nasqar2-%j.out
+#SBATCH --error=nasqar2-%j.err
+
+set -euo pipefail
+
+module purge
+module load singularity/4.2.0
+
+sif="${NASQAR2_SIF:-$SCRATCH/nasqar2/images/nasqar2.sif}"
+launcher="${NASQAR2_LAUNCHER:-$SCRATCH/nasqar2/bin/nasqar2-hpc}"
+runtime_dir="${NASQAR2_RUNTIME_DIR:-$SCRATCH/nasqar2/runs/$SLURM_JOB_ID}"
+port="${NASQAR2_PORT:-$((20000 + SLURM_JOB_ID % 20000))}"
+data_root="${NASQAR2_DATA_ROOT:-$SCRATCH}"
+r_library="${NASQAR2_R_LIBRARY:-$SCRATCH/nasqar2/r-library/R-4.3}"
+atac_cache="${NASQAR2_ATAC_CACHE:-$SCRATCH/nasqar2/cache/ATACseqQC}"
+deseq2_states="${NASQAR2_DESEQ2_STATES:-$SCRATCH/nasqar2/states/DESeq2Shiny}"
+dada2_projects="${NASQAR2_DADA2_PROJECTS:-$SCRATCH/nasqar2/projects/DADA2}"
+seurat_projects="${NASQAR2_SEURAT_PROJECTS:-$SCRATCH/nasqar2/projects/SeuratV5}"
+monocle3_projects="${NASQAR2_MONOCLE3_PROJECTS:-$SCRATCH/nasqar2/projects/Monocle3}"
+node_tmp="${SLURM_TMPDIR:-/tmp/$USER/nasqar2-$SLURM_JOB_ID}"
+
+if [[ ! -f "$sif" ]]; then
+    echo "NASQAR2 image not found: $sif" >&2
+    exit 1
+fi
+if [[ ! -x "$launcher" ]]; then
+    echo "NASQAR2 HPC launcher not found or not executable: $launcher" >&2
+    exit 1
+fi
+if [[ ! -d "$data_root" ]]; then
+    echo "NASQAR2 data root not found: $data_root" >&2
+    exit 1
+fi
+
+mkdir -p "$runtime_dir/R/library" "$r_library" "$atac_cache" "$deseq2_states" \
+    "$dada2_projects" "$seurat_projects" "$monocle3_projects" "$node_tmp/DADA2"
+chmod 700 "$r_library" "$atac_cache" "$deseq2_states" \
+    "$dada2_projects" "$seurat_projects" "$monocle3_projects"
+
+singularity exec --cleanenv \
+    --env "SLURM_JOB_ID=$SLURM_JOB_ID" \
+    --env "SLURM_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK" \
+    --env "NASQAR_DATA_ROOT=$data_root" \
+    --env "NASQAR_ATAC_CACHE_DIR=/runtime/cache/ATACseqQC" \
+    --env "NASQAR_DESEQ2_STATE_DIR=/runtime/states/DESeq2Shiny" \
+    --env "NASQAR_DADA2_PROJECT_DIR=/runtime/projects/DADA2" \
+    --env "NASQAR_DADA2_WORK_DIR=/runtime/node-tmp/DADA2" \
+    --env "NASQAR_SEURAT_PROJECT_DIR=/runtime/projects/SeuratV5" \
+    --env "NASQAR_MONOCLE3_PROJECT_DIR=/runtime/projects/Monocle3" \
+    --env "R_LIBS_USER=/runtime/R/library" \
+    --bind "$runtime_dir:/runtime" \
+    --bind "$atac_cache:/runtime/cache/ATACseqQC" \
+    --bind "$deseq2_states:/runtime/states/DESeq2Shiny" \
+    --bind "$dada2_projects:/runtime/projects/DADA2" \
+    --bind "$seurat_projects:/runtime/projects/SeuratV5" \
+    --bind "$monocle3_projects:/runtime/projects/Monocle3" \
+    --bind "$node_tmp:/runtime/node-tmp" \
+    --bind "$r_library:/runtime/R/library" \
+    --bind "$data_root:$data_root:ro" \
+    --bind "$launcher:/tmp/nasqar2-hpc:ro" \
+    "$sif" \
+    /tmp/nasqar2-hpc \
+    --port "$port" \
+    --runtime /runtime

--- a/hpc/tests/atac-performance-smoke.R
+++ b/hpc/tests/atac-performance-smoke.R
@@ -15,6 +15,14 @@ elapsed <- function(expression) {
     list(value = value, seconds = unname(timing[["elapsed"]]))
 }
 
+requested_workers <- suppressWarnings(as.integer(
+    Sys.getenv("SLURM_CPUS_PER_TASK", unset = "1")
+))
+if (is.na(requested_workers) || requested_workers < 1L) {
+    requested_workers <- 1L
+}
+expected_score_workers <- min(3L, requested_workers)
+
 shiny::testServer(server, {
     session$setInputs(data_file_type = "example_bam_file")
     samples <- input_files_reactive()
@@ -40,7 +48,7 @@ shiny::testServer(server, {
         core_done(),
         !nucleosome_done(),
         !footprint_done(),
-        identical(core_first$score_workers, 3L),
+        identical(core_first$score_workers, expected_score_workers),
         file.exists(core_first$shifted_bam),
         file.exists(paste0(core_first$shifted_bam, ".bai")),
         !is.null(core_first$pt),
@@ -87,7 +95,8 @@ shiny::testServer(server, {
         stopifnot(
             footprint_done(),
             file.exists(footprint$footprint_png),
-            file.exists(footprint$vplot_png)
+            file.exists(footprint$vplot_png),
+            !any(!is.na(dyadEstimateReactive()))
         )
         cat(sprintf(
             "FOOTPRINT elapsed=%.3fs\n",

--- a/hpc/tests/atac-performance-smoke.R
+++ b/hpc/tests/atac-performance-smoke.R
@@ -67,6 +67,7 @@ shiny::testServer(server, {
         nucleosome_trigger <- elapsed(
             session$setInputs(run_nucleosome_plots = 1)
         )
+        stopifnot(nucleosome_done())
         nucleosome <- nucleosomeDataReactive()
         stopifnot(
             nucleosome_done(),
@@ -81,6 +82,7 @@ shiny::testServer(server, {
         footprint_trigger <- elapsed(
             session$setInputs(run_footprint_plots = 1)
         )
+        stopifnot(footprint_done())
         footprint <- footprintDataReactive()
         stopifnot(
             footprint_done(),

--- a/hpc/tests/atac-performance-smoke.R
+++ b/hpc/tests/atac-performance-smoke.R
@@ -1,0 +1,95 @@
+options(warn = 1)
+library(shiny)
+
+app_dir <- Sys.getenv(
+    "NASQAR_ATAC_APP_DIR",
+    unset = "/srv/shiny-server/ATACseqQCShniy/src"
+)
+setwd(app_dir)
+
+source("ui.R", local = globalenv())
+source("server.R", local = globalenv())
+
+elapsed <- function(expression) {
+    timing <- system.time(value <- force(expression))
+    list(value = value, seconds = unname(timing[["elapsed"]]))
+}
+
+shiny::testServer(server, {
+    session$setInputs(data_file_type = "example_bam_file")
+    samples <- input_files_reactive()
+    stopifnot(nrow(samples) > 0)
+
+    sample_name <- rownames(samples)[1]
+    session$setInputs(
+        bs_genome_input = "BSgenome.Hsapiens.UCSC.hg19",
+        sel_sample_for_npositioning = sample_name,
+        sel_chromosome = "chr1",
+        motif_value = "CTCF"
+    )
+
+    stopifnot(
+        !core_done(),
+        !nucleosome_done(),
+        !footprint_done()
+    )
+
+    core_first_trigger <- elapsed(session$setInputs(run_qc = 1))
+    core_first <- inputDataReactive()
+    stopifnot(
+        core_done(),
+        !nucleosome_done(),
+        !footprint_done(),
+        identical(core_first$score_workers, 3L),
+        file.exists(core_first$shifted_bam),
+        file.exists(paste0(core_first$shifted_bam, ".bai")),
+        !is.null(core_first$pt),
+        !is.null(core_first$nfr),
+        !is.null(core_first$tsse)
+    )
+
+    core_cached_trigger <- elapsed(session$setInputs(run_qc = 2))
+    core_cached <- inputDataReactive()
+    stopifnot(
+        identical(core_first$key, core_cached$key),
+        core_cached_trigger$seconds < core_first_trigger$seconds
+    )
+
+    cat(sprintf(
+        "CORE cold=%.3fs cached=%.3fs workers=%d cache=%s\n",
+        core_first_trigger$seconds,
+        core_cached_trigger$seconds,
+        core_first$score_workers,
+        core_first$cache_dir
+    ))
+
+    if (identical(Sys.getenv("NASQAR_ATAC_TEST_ADVANCED"), "1")) {
+        nucleosome_trigger <- elapsed(
+            session$setInputs(run_nucleosome_plots = 1)
+        )
+        nucleosome <- nucleosomeDataReactive()
+        stopifnot(
+            nucleosome_done(),
+            all(file.exists(nucleosome$bamfiles)),
+            !is.null(nucleosome$distribution)
+        )
+        cat(sprintf(
+            "NUCLEOSOME elapsed=%.3fs\n",
+            nucleosome_trigger$seconds
+        ))
+
+        footprint_trigger <- elapsed(
+            session$setInputs(run_footprint_plots = 1)
+        )
+        footprint <- footprintDataReactive()
+        stopifnot(
+            footprint_done(),
+            file.exists(footprint$footprint_png),
+            file.exists(footprint$vplot_png)
+        )
+        cat(sprintf(
+            "FOOTPRINT elapsed=%.3fs\n",
+            footprint_trigger$seconds
+        ))
+    }
+})

--- a/hpc/tests/deseq2-hpc-state-modal-smoke.R
+++ b/hpc/tests/deseq2-hpc-state-modal-smoke.R
@@ -1,0 +1,16 @@
+app_dir <- Sys.getenv(
+    "NASQAR_DESEQ2_APP_DIR",
+    unset = "/srv/shiny-server/deseq2shiny/src"
+)
+setwd(app_dir)
+
+source("global.R", local = globalenv())
+source("ui.R", local = globalenv())
+source("server.R", local = globalenv())
+
+shiny::testServer(server, {
+    session$setInputs(showStateModal = 1)
+    session$flushReact()
+})
+
+cat("DESeq2 HPC state modal opened without a server error.\n")

--- a/hpc/tests/publication-export-contract.R
+++ b/hpc/tests/publication-export-contract.R
@@ -1,0 +1,119 @@
+read_sources <- function(directory, pattern) {
+    files <- list.files(directory, pattern = pattern, full.names = TRUE)
+    paste(
+        vapply(
+            files,
+            function(file) paste(readLines(file, warn = FALSE), collapse = "\n"),
+            FUN.VALUE = character(1)
+        ),
+        collapse = "\n"
+    )
+}
+
+assert_ids <- function(label, ui_text, server_text, ids) {
+    missing_ui <- ids[!vapply(
+        ids,
+        function(id) grepl(id, ui_text, fixed = TRUE),
+        logical(1)
+    )]
+    missing_server <- ids[!vapply(
+        ids,
+        function(id) grepl(id, server_text, fixed = TRUE),
+        logical(1)
+    )]
+    if (length(missing_ui) || length(missing_server)) {
+        stop(
+            label,
+            " publication export mismatch. UI: ",
+            paste(missing_ui, collapse = ", "),
+            "; server: ",
+            paste(missing_server, collapse = ", "),
+            call. = FALSE
+        )
+    }
+}
+
+dada_ui <- read_sources("dada2Shiny/src", "^ui-tab-.*\\.R$")
+dada_server <- read_sources("dada2Shiny/src", "^server-.*\\.R$")
+assert_ids(
+    "DADA2",
+    dada_ui,
+    dada_server,
+    c(
+        "download_quality_forward", "download_quality_reverse",
+        "download_error_forward", "download_error_reverse",
+        "download_fragments_summary",
+        "download_sequence_distribution", "download_alpha_diversity",
+        "download_ordination", "download_composition"
+    )
+)
+
+atac_ui <- read_sources("ATACseqQCShniy/src", "^ui-tab-.*\\.R$")
+atac_server <- read_sources("ATACseqQCShniy/src", "^server-.*\\.R$")
+assert_ids(
+    "ATACseqQC",
+    atac_ui,
+    atac_server,
+    c(
+        "download_replicate_heatmap", "download_library_complexity",
+        "download_fragment_size", "download_pt_score", "download_nfr_score",
+        "download_tss_enrichment", "download_cumulative_tags",
+        "download_tss_heatmap", "download_nucleosome_signals",
+        "download_footprint", "download_binding_heatmap", "download_vplot",
+        "download_dyad_distance"
+    )
+)
+
+deseq_ui <- read_sources("deseq2shiny/src", "^ui-tab-.*\\.R$")
+deseq_server <- read_sources("deseq2shiny/src", "^server-.*\\.R$")
+assert_ids(
+    "DESeq2Shiny",
+    deseq_ui,
+    deseq_server,
+    c(
+        "download_ma_plot", "download_volcano_plot", "download_venn_plot",
+        "download_boxplot", "downloadHighResHeatmap",
+        "download_vst_distance", "download_vst_pca",
+        "download_rlog_distance", "download_rlog_pca",
+        "download_sva_scatter", "download_sva_pca"
+    )
+)
+
+for (application in c("ClusterProfShinyORA", "ClusterProfShinyGSEA")) {
+    helper <- paste(readLines(
+        file.path(application, "src", "plot-helpers.R"),
+        warn = FALSE
+    ), collapse = "\n")
+    if (!grepl("res    = 300", helper, fixed = TRUE) ||
+        !grepl("toImageButtonOptions", helper, fixed = TRUE) ||
+        grepl("error = function(e) NULL", helper, fixed = TRUE)) {
+        stop(application, paste(
+            "must export static PNG at 300 DPI, configure high-resolution",
+            "interactive downloads, and propagate errors."
+        ),
+             call. = FALSE)
+    }
+
+    server <- read_sources(file.path(application, "src"), "^server-.*\\.R$")
+    ui <- read_sources(file.path(application, "src"), "^ui-tab-.*\\.R$")
+    handler_ids <- unique(unlist(regmatches(
+        server,
+        gregexpr(
+            '(?<=make_downloader\\(output, ")[^"]+',
+            server,
+            perl = TRUE
+        )
+    )))
+    for (id in handler_ids) {
+        if (!grepl(paste0('plot_dl_buttons("', id, '")'), ui, fixed = TRUE)) {
+            stop(application, " is missing download controls for ", id,
+                 call. = FALSE)
+        }
+    }
+}
+
+gene_merger <- paste(readLines("GeneCountMerger/src/app.R", warn = FALSE),
+                     collapse = "\n")
+stopifnot(grepl("downloadHandler", gene_merger, fixed = TRUE))
+
+cat("Publication export contracts passed.\n")

--- a/monocle3/src/app.R
+++ b/monocle3/src/app.R
@@ -18,9 +18,7 @@ library(monocle3)
 library(stringr)
 library(SeuratWrappers)
 library(mclust)
-library(genesorteR)
 library(pheatmap)
-library(dqshiny)
 
 # Change data load maximum
 options(shiny.maxRequestSize = 115*1024^3)
@@ -50,10 +48,33 @@ ui <- shinyUI(fluidPage(
                         
                         # Create Input
                         fluidRow(column(2, wellPanel(
-                        fileInput("file", 'Choose Rdata/Rds to upload',
+                        radioButtons(
+                          "data_source",
+                          "Seurat object source",
+                          c(
+                            "Upload from browser" = "upload",
+                            "Use HPC scratch file" = "hpc"
+                          ),
+                          selected = "upload"
+                        ),
+                        conditionalPanel(
+                          "input.data_source == 'upload'",
+                          fileInput("file", 'Choose Rdata/Rds to upload',
                                     accept = c('.Rdata', ".rds", ".Rds")),
+                          actionButton("upload", "Upload")
+                        ),
+                        conditionalPanel(
+                          "input.data_source == 'hpc'",
+                          textInput(
+                            "hpc_input_path",
+                            "Seurat .rds or .RData file inside HPC scratch",
+                            value = ""
+                          ),
+                          actionButton("load_hpc", "Load HPC Object")
+                        ),
+                        textInput("hpc_project_name", "Persistent project name", value = "monocle3-project"),
                         #Set load button
-                        actionButton("upload", "Upload"),
+                        textOutput("hpc_output_path"),
                         
                         fluidRow(tags$hr(style="border-color: black;")),
                         
@@ -68,7 +89,7 @@ ui <- shinyUI(fluidPage(
                                     NULL),
                         
                         #Set progenitor gene
-                        autocomplete_input("gene", "Progenitor gene:", NULL),
+                        textInput("gene", "Progenitor gene:", value = ""),
                         
                         #Set load button
                         actionButton("run", "Run Monocle3"),
@@ -99,6 +120,84 @@ ui <- shinyUI(fluidPage(
 
 # Define server logic
 server <- shinyServer(function(input, output, session) {
+  seurat_data <- reactiveVal(NULL)
+  monocle_workers <- suppressWarnings(
+    as.integer(Sys.getenv("SLURM_CPUS_PER_TASK", "1"))
+  )
+  if (is.na(monocle_workers) || monocle_workers < 1L) monocle_workers <- 1L
+
+  resolve_hpc_path <- function(path) {
+    root <- normalizePath(
+      Sys.getenv("NASQAR_DATA_ROOT", unset = "/scratch/nr83"),
+      mustWork = TRUE
+    )
+    resolved <- normalizePath(path, mustWork = TRUE)
+    allowed <- identical(resolved, root) ||
+      startsWith(resolved, paste0(root, .Platform$file.sep))
+    if (!allowed) stop("The file must be inside the configured HPC data root.")
+    if (dir.exists(resolved)) stop("Select a Seurat .rds or .RData file, not a directory.")
+    resolved
+  }
+
+  project_directory <- function(name) {
+    root <- Sys.getenv("NASQAR_MONOCLE3_PROJECT_DIR", unset = "")
+    if (!nzchar(root)) return(tempdir())
+    safe_name <- gsub("[^A-Za-z0-9._-]+", "-", trimws(name))
+    if (!nzchar(safe_name)) safe_name <- "monocle3-project"
+    path <- file.path(root, safe_name)
+    dir.create(path, recursive = TRUE, showWarnings = FALSE, mode = "0700")
+    if (!dir.exists(path) || file.access(path, 2) != 0) {
+      stop("The Monocle3 HPC project directory is not writable.")
+    }
+    path
+  }
+
+  read_seurat_file <- function(path) {
+    if (grepl("\\.rdata$", path, ignore.case = TRUE)) {
+      load_env <- new.env(parent = emptyenv())
+      object_names <- load(path, envir = load_env)
+      candidates <- object_names[
+        vapply(object_names, function(name) inherits(load_env[[name]], "Seurat"), logical(1))
+      ]
+      validate(need(length(candidates) == 1L, "The .RData file must contain exactly one Seurat object."))
+      load_env[[candidates[[1L]]]]
+    } else {
+      readRDS(path)
+    }
+  }
+
+  configure_seurat_input <- function(data) {
+    validate(need(inherits(data, "Seurat"), "The transferred object is not a Seurat object."))
+    seurat_data(data)
+    updateSelectInput(session, "assay", "Select assay", choices = names(data@assays))
+    updateSelectInput(
+      session, "ident", "Select Identity for clustering",
+      choices = colnames(data@meta.data)
+    )
+    shinyjs::enable("gene")
+    shinyjs::enable("assay")
+    shinyjs::enable("ident")
+    shinyjs::enable("run")
+  }
+
+  read_exchange_object <- function(token) {
+    validate(need(
+      length(token) == 1L &&
+        grepl("^[0-9a-fA-F-]{36}$", token),
+      "Invalid NASQAR2 transfer token."
+    ))
+    exchange_dir <- file.path(tempdir(check = TRUE), "..", "nasqar_exchange")
+    exchange_dir <- normalizePath(exchange_dir, mustWork = FALSE)
+    path <- file.path(exchange_dir, paste0(token, ".rds"))
+    validate(need(file.exists(path), "The transferred Seurat object has expired."))
+    validate(need(
+      as.numeric(difftime(Sys.time(), file.info(path)$mtime, units = "secs")) <= 3600,
+      "The transferred Seurat object has expired."
+    ))
+    object <- readRDS(path)
+    unlink(path)
+    object
+  }
   
   #Set text outputs
   output$title <- renderText("Pseudotime projection with Monocle3")
@@ -109,12 +208,7 @@ server <- shinyServer(function(input, output, session) {
     rdata <- isolate({input$file})
     short <- input$file
     
-    if(grepl(".Rdata", short$name)) {
-    load(rdata$datapath, envir = .GlobalEnv)
-    data <- get(names(which(unlist(eapply(.GlobalEnv, is.Seurat)))))
-    } else {
-    data <- readRDS(rdata$datapath)
-    }
+    data <- read_seurat_file(rdata$datapath)
     
     return(data)
   }
@@ -134,37 +228,61 @@ server <- shinyServer(function(input, output, session) {
   
   observeEvent(input$upload,{
     data <- load_Rdata()
-    
-    #data <- UpdateSeuratObject(object = data)
-    
-    str(rownames(data))
-    
-    #Update assay list
-    updateSelectInput(session, "assay", "Select assay", choices = names(data@assays))
-    
-    #Update identity list
-    updateSelectInput(session, "ident", "Select Identity for clustering", choices = colnames(data@meta.data))
-    
-    #Update autocomplete for gene searching
-    genes <- unique(rownames(data))
-    update_autocomplete_input(session, "gene",
-                              options = genes)
-    
-    #Enable buttons
-    shinyjs::enable("gene")
-    shinyjs::enable("assay")
-    shinyjs::enable("ident")
-    shinyjs::enable("run")
-  
+    configure_seurat_input(data)
+  })
+
+  observeEvent(input$load_hpc, {
+    validate(need(nzchar(trimws(input$hpc_input_path)), "Enter an HPC Seurat object path."))
+    path <- tryCatch(
+      resolve_hpc_path(input$hpc_input_path),
+      error = function(e) {
+        validate(need(FALSE, e$message))
+      }
+    )
+    configure_seurat_input(read_seurat_file(path))
+    showNotification("Seurat object loaded directly from HPC scratch.", type = "message")
+  })
+
+  observeEvent(TRUE, {
+    query <- parseQueryString(session$clientData$url_search)
+    if (!is.null(query[["exchange"]])) {
+      configure_seurat_input(read_exchange_object(query[["exchange"]]))
+      showNotification(
+        "Seurat object transferred from SeuratV5Shiny.",
+        type = "message"
+      )
+    }
+  }, once = TRUE)
+
   # Create event when report load button is activated
   observeEvent(input$run,{
+    data <- seurat_data()
+    req(data)
     
     #Set assay
     DefaultAssay(data) <- input$assay
     
     #Create progress bar
     withProgress(message = 'Running Monocle3...please wait', {
-    out <- mon.run(data=data, gene=input$gene, id=input$ident)
+    out <- mon.run(data=data, gene=input$gene, id=input$ident, cores=monocle_workers)
+    })
+
+    output_dir <- project_directory(input$hpc_project_name)
+    saveRDS(out$seurat, file.path(output_dir, "seurat-with-monocle3-pseudotime.rds"))
+    saveRDS(out$cds, file.path(output_dir, "monocle3-cell-data-set.rds"))
+    write.csv(out$t1, file.path(output_dir, "monocle3-pseudotime-results.csv"), row.names = FALSE)
+    pdf(file.path(output_dir, "monocle3-plots.pdf"), width = 10, height = 8)
+    print(out$dim)
+    print(out$p1)
+    print(out$p2)
+    print(out$p3)
+    print(out$p4)
+    print(out$p5)
+    dev.off()
+    output$hpc_output_path <- renderText({
+      if (nzchar(Sys.getenv("NASQAR_MONOCLE3_PROJECT_DIR", ""))) {
+        paste("Saved persistently on HPC:", output_dir)
+      }
     })
     
     output$dim <- renderPlot({out$dim})
@@ -218,9 +336,7 @@ server <- shinyServer(function(input, output, session) {
           })
   
       })
-  })
 })
 
 # Run the application 
 shinyApp(ui = ui, server = server)
-

--- a/monocle3/src/source.R
+++ b/monocle3/src/source.R
@@ -1,4 +1,4 @@
-mon.run <- function(data, gene, id) {
+mon.run <- function(data, gene, id, cores = 1L) {
   
 
   print(gene)
@@ -44,9 +44,10 @@ mon.run <- function(data, gene, id) {
   cds <- suppressWarnings(as.cell_data_set(data))
   
  
-  # Cluster cells with Leiden clustering
-  #cds <- cluster_cells(cds)
-  cds <- cluster_cells(cds, cluster_methods = 'leiden', reduction_method = 'UMAP')
+  # as.cell_data_set() carries the selected Seurat clusters into the UMAP
+  # cluster slot. Reuse them here; reclustering currently fails with recent
+  # igraph releases that require a strictly symmetric adjacency matrix.
+  names(cds@clusters$UMAP$partitions) <- colnames(cds)
 
   print('done...')
   #Inc process
@@ -118,65 +119,78 @@ mon.run <- function(data, gene, id) {
   #Inc process
   incProgress(amount = 0.1)
   
-  # Find differentially expressed genes
-  cds <-  estimate_size_factors(cds)
-  
-  # Set gene names
-  #cds@rowRanges@elementMetadata@listData[['gene_short_name']] <- rownames(data[['integrated']])
-  
-  #Inc process
-  incProgress(amount = 0.1)
-  
-  # Create table of DE genes
-  cds_dif_test <- graph_test(cds, neighbor_graph = 'principal_graph', cores = 4)
-  
-  #Set table for output
-  t1 <- cds_dif_test
-  
-  #Select significant genes
-  cds_dif_test <-  cds_dif_test[cds_dif_test$q_value < 0.05,]
-  
-  #Inc process
-  incProgress(amount = 0.1)
-  
-  # Get top genes
-  gene.list <-  cds_dif_test %>% arrange(desc(morans_test_statistic), desc(-q_value)) %>% rownames()
-  top.genes <- gene.list[1:40]
-  
-  # Select top genes
-  top <- cds_dif_test[rownames(cds_dif_test) %in% top.genes,]
-  
-  
-  str(AggregateExpression(data, assays = "RNA", features = top.genes))
-  print('top')
-  print(top)
-  # Count mean expression of top genes
-  summ <- AggregateExpression(data, assays = "RNA", features = top.genes) %>% as.data.frame()
-  summ$all <- rowMeans(summ)
-  
-  # Edit top genes to remove those with 0 expression
-  top.genes <- row.names(summ)[summ$all > 0]
-  
-  # Cluster cells (based on pseudotime) for heatmap
-  data$monocle3_pseudotime[data$monocle3_pseudotime == "Inf"] <- 0 
-  kk <- Mclust(-data$monocle3_pseudotime, 5, modelNames = 'E')
+  # The trajectory result is the core analysis and should not depend on the
+  # optional genesorteR marker-heatmap package.
+  t1 <- data.frame(
+    cell = colnames(cds),
+    pseudotime = pseudotime(cds),
+    row.names = NULL
+  )
 
-  #Inc process
-  incProgress(amount = 0.1)
-  
-  # Cluster genes with k-means clustering
-  #p5 <- plotMarkerHeat(data@assays$RNA@data[,order(data$monocle3_pseudotime, decreasing = FALSE)], 
-  #	kk$classification[order(data$monocle3_pseudotime, decreasing = TRUE)], 
-  #	top.genes, averageCells = 10^1, clusterGenesK = 5, clusterGenes = TRUE, 
-  #	gap = FALSE, outs = TRUE, plotheat = TRUE) # fontsize = 20)
-  
-  p5 <- plotMarkerHeat(data@assays$RNA$data[,order(data$monocle3_pseudotime, decreasing = FALSE)], 
-                       kk$classification[order(data$monocle3_pseudotime, decreasing = TRUE)], 
-                       top.genes, averageCells = 10^1, clusterGenesK = 5, clusterGenes = TRUE, 
-                       gap = FALSE, outs = TRUE, plotheat = TRUE) # fontsize = 20)
+  if (requireNamespace("genesorteR", quietly = TRUE)) {
+    cds <- estimate_size_factors(cds)
+    cds_dif_test <- graph_test(
+      cds,
+      neighbor_graph = "principal_graph",
+      cores = cores
+    )
+    t1 <- cds_dif_test
+    cds_dif_test <- cds_dif_test[cds_dif_test$q_value < 0.05, ]
+    gene.list <- cds_dif_test %>%
+      arrange(desc(morans_test_statistic), desc(-q_value)) %>%
+      rownames()
+    top.genes <- head(gene.list, 40)
+    summ <- AggregateExpression(
+      data,
+      assays = "RNA",
+      features = top.genes
+    ) %>%
+      as.data.frame()
+    summ$all <- rowMeans(summ)
+    top.genes <- row.names(summ)[summ$all > 0]
+
+    data$monocle3_pseudotime[is.infinite(data$monocle3_pseudotime)] <- 0
+    kk <- Mclust(-data$monocle3_pseudotime, 5, modelNames = "E")
+    expression_matrix <- LayerData(data, assay = "RNA", layer = "data")
+    p5 <- genesorteR::plotMarkerHeat(
+      expression_matrix[
+        ,
+        order(data$monocle3_pseudotime, decreasing = FALSE)
+      ],
+      kk$classification[
+        order(data$monocle3_pseudotime, decreasing = TRUE)
+      ],
+      top.genes,
+      averageCells = 10,
+      clusterGenesK = 5,
+      clusterGenes = TRUE,
+      gap = FALSE,
+      outs = TRUE,
+      plotheat = TRUE
+    )
+  } else {
+    p5 <- ggplot() +
+      annotate(
+        "text",
+        x = 0,
+        y = 0,
+        label = "Optional genesorteR heatmap is unavailable"
+      ) +
+      theme_void()
+  }
 
   # Create output list
-  out <- list(dim=dim, p1=p1, p2=p2, p3=p3, p4=p4, p5=p5, t1=t1)
+  out <- list(
+    dim=dim,
+    p1=p1,
+    p2=p2,
+    p3=p3,
+    p4=p4,
+    p5=p5,
+    t1=t1,
+    seurat=data,
+    cds=cds
+  )
   
 return(out)
   

--- a/nasqar_swarm/docker_compose.yml
+++ b/nasqar_swarm/docker_compose.yml
@@ -4,6 +4,10 @@ services:
 
   nasqar:
     image: nyuadcorebio/nasqarall:latest
+    environment:
+      NASQAR_EXCHANGE_DIR: /runtime/exchange
+    volumes:
+      - ${NASQAR_EXCHANGE_HOST_DIR:-/data/nasqar_swarm/exchange}:/runtime/exchange
     networks:
       - net
     deploy:
@@ -64,4 +68,3 @@ services:
 networks:
   net:
     driver: overlay
-

--- a/nginx.conf
+++ b/nginx.conf
@@ -89,7 +89,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -120,7 +121,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -149,7 +151,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -170,7 +173,9 @@ http {
         location ~* ^/ClusterProfShinyORA/.*\.map$ {
             access_log off;
             log_not_found off;
-            return 204;
+            default_type application/json;
+            add_header Cache-Control "public, max-age=86400";
+            return 200 '{"version":3,"sources":[],"names":[],"mappings":""}';
         }
 
         location /ClusterProfShinyORA/ {
@@ -178,7 +183,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -207,7 +213,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -236,7 +243,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -265,7 +273,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -294,7 +303,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -323,7 +333,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -352,7 +363,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -381,7 +393,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -410,7 +423,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -430,4 +444,3 @@ http {
 
     }
 }
-


### PR DESCRIPTION
## Summary

- secure shared exchange handoffs across Gene Count Merger, DESeq2Shiny, DADA2/animalcules, ORA, and GSEA
- make ATACseqQC, DADA2, Seurat v5, Monocle 3, and DESeq2 workflows HPC-aware
- improve ATACseqQC and DADA2 performance with reusable computation and parallel execution
- fix workflow reliability, responsive layouts, and cross-module data handling
- standardize scientific plot presentation and add publication-ready PNG, PDF, and SVG exports
- add regression tests for exchange, HPC state, module loading, and publication exports

## Validation

- Gene Count Merger regression tests
- DADA2 helper and source tests
- ORA/GSEA exchange and source tests
- DESeq2 core, module, and HPC state tests
- ATACseqQC advanced smoke tests under `v_atacqc`
- publication export contract tests
- `git diff --check`